### PR TITLE
fix: [AI & 머신러닝] AI Hub API 이름 및 설명 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@
 | [SKT A.X 4.0](https://github.com/SKT-AI/A.X-4.0)                                           | 한국어 특화 대규모 언어모델                      | `apiKey` |
 | [ETRI AI Open API](https://epretx.etri.re.kr/)                                             | 한국전자통신연구원 AI 서비스 플랫폼                 | `apiKey` |
 | [카카오 카나나 AI API](https://www.kakaocorp.com/page/detail/11566)                              | 카카오 자체 개발 한국어 특화 생성형 AI 모델 4종 (오픈소스) | `apiKey` |
-| [AI Hub 번역 데이터](https://aihub.or.kr/devsport/apishell/list.do?currMenu=403&topMenu=100)    | AI 학습용 한국어-다국어 병렬 말뭉치 및 번역 데이터셋      | `apiKey` |
+| [AI Hub](https://aihub.or.kr)                                                              | AI 학습용 데이터셋                              | `apiKey` |
 
 **[⬆ 목차로 돌아가기](#목차)**
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -246,7 +246,7 @@ Updated with the latest information as of 2025, and will be periodically updated
 | [SKT A.X 4.0](https://github.com/SKT-AI/A.X-4.0)                                                  | Korean-specialized large language model                                            | `apiKey` |
 | [ETRI AI Open API](https://epretx.etri.re.kr/)                                                    | Electronics and Telecommunications Research Institute AI service platform          | `apiKey` |
 | [Kakao Kanana AI API](https://www.kakaocorp.com/page/detail/11566)                                | Kakao's proprietary Korean-specialized generative AI models (4 types, open source) | `apiKey` |
-| [AI Hub Translation Data](https://aihub.or.kr/devsport/apishell/list.do?currMenu=403&topMenu=100) | Korean-Multilingual Parallel Corpus and Translation Dataset for AI Training        | `apiKey` |
+| [AI Hub](https://aihub.or.kr)                                                                     | Dataset for AI Training                                                            | `apiKey` |
 
 **[⬆ Back to Table of Contents](#table-of-contents)**
 
@@ -540,3 +540,4 @@ This project is distributed under the MIT License.
 **Last Updated**: September 9, 2025
 
 **Total API Count**: 225+
+


### PR DESCRIPTION
AI Hub는 다양한 AI 학습용 데이터셋을 제공하는 플랫폼으로, 기존에는 특정 데이터셋만 제공한다고 명시되어 있었기 때문에 수정합니다.