### PR TITLE
Update global API translation source

### DIFF
--- a/GLOBAL_PUBLIC_APIS_KR.md
+++ b/GLOBAL_PUBLIC_APIS_KR.md
@@ -1,1156 +1,1919 @@
 # 🌍 Global Public API
 
 > 번역 저장소 안내 👀
-> 
-> 이 Global Public API는 한국어 사용 개발자를 위해 [public-api-lists](https://github.com/public-api-lists/public-api-lists) 저장소를 포크하여 번역 및 데이터를 추가한 저장소입니다.
 >
-> MIT 라이선스 하에 번역 및 배포됩니다.
+> 이 문서는 한국어 사용 개발자를 위해 [public-apis/public-apis](https://github.com/public-apis/public-apis) 저장소의 공개 API 목록을 한국어로 옮긴 문서입니다.
+> 원본 기준: `master` 커밋 [`67c9716`](https://github.com/public-apis/public-apis/commit/67c9716530789b09d388bd2c6443af7a215e81e5) (2026-05-11 05:50:32 UTC)
+>
+> 원본 저장소와 동일하게 MIT 라이선스 하에 번역 및 배포됩니다.
 
 ## 목차
 
+- [APILayer API](#apilayer-api)
 - [Public API 목록](#public-api-목록)
-    - [목차](#목차)
-        -  🐾 [동물](#동물)
-        -  🎬 [애니메이션](#애니메이션)
-        -  🛡️ [안티 멀웨어](#안티-멀웨어)
-        -  🎨 [아트 & 디자인](#아트--디자인)
-        -  📚 [도서](#도서)
-        -  💼 [비즈니스](#비즈니스)
-        -  📅 [캘린더](#캘린더)
-        -  ☁️ [클라우드 스토리지 & 파일 공유](#클라우드-스토리지--파일-공유)
-        -  🔄 [지속적 통합](#지속적-통합)
-        -  💰 [암호화폐](#암호화폐)
-        -  💱 [환율](#환율)
-        -  ✅ [데이터 검증](#데이터-검증)
-        -  💻 [개발](#개발)
-        -  📖 [사전](#사전)
-        -  🚨 [재해](#재해)
-        -  📄 [문서 & 생산성](#문서--생산성)
-        -  🎓 [교육](#교육)
-        -  🌱 [환경](#환경)
-        -  🎉 [이벤트](#이벤트)
-        -  🏦 [금융](#금융)
-        -  🍕 [음식 & 음료](#음식--음료)
-        -  🚫 [사기 방지](#사기-방지)
-        -  🎮 [게임 & 만화](#게임--만화)
-        -  📍 [지오코딩](#지오코딩)
-        -  🏛️ [정부](#정부)
-        -  🏥 [건강](#건강)
-        -  💼 [채용](#채용)
-        -  🤖 [기계 학습](#기계-학습)
-        -  🎵 [음악](#음악)
-        -  📰 [뉴스](#뉴스)
-        -  📊 [오픈 데이터](#오픈-데이터)
-        -  🔓 [오픈 소스 프로젝트](#오픈-소스-프로젝트)
-        -  📋 [특허](#특허)
-        -  🧠 [성격](#성격)
-        -  📸 [사진](#사진)
-        -  🧪 [과학 & 수학](#과학--수학)
-        -  🔒 [보안](#보안)
-        -  🛒 [쇼핑](#쇼핑)
-        -  👥 [소셜](#소셜)
-        -  ⚽ [스포츠 & 피트니스](#스포츠--피트니스)
-        -  🧪 [테스트 데이터](#테스트-데이터)
-        -  📝 [텍스트 분석](#텍스트-분석)
-        -  📦 [추적](#추적)
-        -  🚗 [교통](#교통)
-        -  🔗 [URL 단축기](#url-단축기)
-        -  🚙 [차량](#차량)
-        -  🎥 [비디오](#비디오)
-        -  🌤️ [날씨](#날씨)
+  - 🐾 [동물](#동물)
+  - 🎬 [애니메이션](#애니메이션)
+  - 🛡️ [안티 멀웨어](#안티-멀웨어)
+  - 🎨 [아트 & 디자인](#아트-디자인)
+  - 🔐 [인증 & 권한 부여](#인증-권한-부여)
+  - ⛓️ [블록체인](#블록체인)
+  - 📚 [도서](#도서)
+  - 💼 [비즈니스](#비즈니스)
+  - 📅 [캘린더](#캘린더)
+  - ☁️ [클라우드 스토리지 & 파일 공유](#클라우드-스토리지-파일-공유)
+  - 🔄 [지속적 통합](#지속적-통합)
+  - 💰 [암호화폐](#암호화폐)
+  - 💱 [환율](#환율)
+  - ✅ [데이터 검증](#데이터-검증)
+  - 💻 [개발](#개발)
+  - 📖 [사전](#사전)
+  - 📄 [문서 & 생산성](#문서-생산성)
+  - ✉️ [이메일](#이메일)
+  - 🎭 [엔터테인먼트](#엔터테인먼트)
+  - 🌱 [환경](#환경)
+  - 🎉 [이벤트](#이벤트)
+  - 🏦 [금융](#금융)
+  - 🍕 [음식 & 음료](#음식-음료)
+  - 🎮 [게임 & 만화](#게임-만화)
+  - 📍 [지오코딩](#지오코딩)
+  - 🏛️ [정부](#정부)
+  - 🏥 [건강](#건강)
+  - 💼 [채용](#채용)
+  - 🤖 [기계 학습](#기계-학습)
+  - 🎵 [음악](#음악)
+  - 📰 [뉴스](#뉴스)
+  - 📊 [오픈 데이터](#오픈-데이터)
+  - 🔓 [오픈 소스 프로젝트](#오픈-소스-프로젝트)
+  - 📋 [특허](#특허)
+  - 🧠 [성격](#성격)
+  - ☎️ [전화](#전화)
+  - 📸 [사진](#사진)
+  - ⌨️ [프로그래밍](#프로그래밍)
+  - 🧪 [과학 & 수학](#과학-수학)
+  - 🔒 [보안](#보안)
+  - 🛒 [쇼핑](#쇼핑)
+  - 👥 [소셜](#소셜)
+  - ⚽ [스포츠 & 피트니스](#스포츠-피트니스)
+  - 🧪 [테스트 데이터](#테스트-데이터)
+  - 📝 [텍스트 분석](#텍스트-분석)
+  - 📦 [추적](#추적)
+  - 🚗 [교통](#교통)
+  - 🔗 [URL 단축기](#url-단축기)
+  - 🚙 [차량](#차량)
+  - 🎥 [비디오](#비디오)
+  - 🌤️ [날씨](#날씨)
+
+## APILayer API
+
+| API | 설명 | 호출하기 |
+| :--- | --- | :---: |
+| [IPstack](https://ipstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | IP 주소로 웹사이트 방문자 찾기 및 식별 | [Run in Postman](https://god.gw.postman.com/run-collection/10131015-55145132-244c-448c-8e6f-8780866e4862?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D10131015-55145132-244c-448c-8e6f-8780866e4862%26entityType%3Dcollection%26workspaceId%3D2b7498b6-6d91-4fa8-817f-608441fe42a8) |
+| [Marketstack](https://marketstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 전 세계 주식 시장 데이터를 JSON 형식으로 제공하는 사용하기 쉬운 무료 REST API 인터페이스 | [Run in Postman](https://god.gw.postman.com/run-collection/10131015-9cbac391-3611-4f50-9bfd-d24ae41c97c1?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D10131015-9cbac391-3611-4f50-9bfd-d24ae41c97c1%26entityType%3Dcollection%26workspaceId%3D2b7498b6-6d91-4fa8-817f-608441fe42a8) |
+| [Weatherstack](https://weatherstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 경량 JSON 형식으로 전 세계 모든 위치에 대한 즉각적이고 정확한 날씨 정보를 검색합니다. | [Run in Postman](https://god.gw.postman.com/run-collection/10131015-276c4312-f682-425d-b6b1-0f82c0a7f2b3?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D10131015-276c4312-f682-425d-b6b1-0f82c0a7f2b3%26entityType%3Dcollection%26workspaceId%3D2b7498b6-6d91-4fa8-817f-608441fe42a8) |
+| [Numverify](https://numverify.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 글로벌 전화번호 확인 및 조회 JSON API | [Run in Postman](https://god.gw.postman.com/run-collection/10131015-0760d25e-b802-412e-b0e4-26e5ca3b9ffa?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D10131015-0760d25e-b802-412e-b0e4-26e5ca3b9ffa%26entityType%3Dcollection%26workspaceId%3D2b7498b6-6d91-4fa8-817f-608441fe42a8) |
+| [Fixer](https://fixer.io/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | Fixer는 현재 및 과거 외환(외환) 환율에 대한 간단하고 가벼운 API. | [Run in Postman](https://god.gw.postman.com/run-collection/10131015-0d9c66b3-5f1a-42ed-a5ca-379217bd629d?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D10131015-0d9c66b3-5f1a-42ed-a5ca-379217bd629d%26entityType%3Dcollection%26workspaceId%3D2b7498b6-6d91-4fa8-817f-608441fe42a8) |
+| [Aviationstack](https://aviationstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 무료 실시간 비행 상태 및 글로벌 항공 데이터 API | [Run in Postman](https://god.gw.postman.com/run-collection/10131015-72ee0d35-018e-4370-a2b6-a66d3ebd5b5a?action=collection/fork) |
+| [Zenserp](https://zenserp.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 개발자를 위해 구축된 빠르고 정확한 Google 검색 데이터 | [Run in Postman](https://god.gw.postman.com/run-collection/10131015-a3d63243-081e-4961-a2f0-39c7a9394b8d?action=collection/fork) |
+| [Screenshotlayer](https://screenshotlayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 모든 웹사이트의 고도로 사용자 정의 가능한 스크린샷을 캡처하세요 | [문서](https://docs.apilayer.com/screenshotlayer/docs/api-documentation?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) |
+| [Exchangerate Host](https://exchangerate.host/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 실시간 현재 및 과거 외환 및 암호화폐 환율 | [문서](https://docs.apilayer.com/Exchangerate/docs/api-documentation?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) |
+| [Mailboxlayer](https://mailboxlayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 개발자를 위한 이메일 검증 및 검증 JSON API | [문서](https://docs.apilayer.com/mailboxlayer/docs/api-documentation?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) |
+
+**[⬆ 목차로 돌아가기](#목차)**
+
+## Public API 목록
 
 ### 동물
 
-|                                            API                                             | 설명                                |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------------------------------------------------: | ----------------------------------- | :------: | :---: | :-----: |
-|                      [Amazing Endemic Species](https://aes.shenlu.me)                      | 전 세계의 놀라운 고유종             |    No    |  Yes  |   Yes   |
-|                  [Cat Facts](https://alexwohlbruck.github.io/cat-facts/)                   | 매일 새로운 고양이 팩트             |    No    |  Yes  |   No    |
-|                            [Cats](https://docs.thecatapi.com/)                             | Tumblr의 고양이 사진                | `apiKey` |  Yes  | Unknown |
-|                               [Cataas](https://cataas.com/)                                | 고양이 서비스 (고양이 사진과 GIF)   |    No    |  Yes  | Unknown |
-|                               [Dog API](https://dogapi.dog)                                | 개 품종과 그룹에 대한 재미있는 사실 |    No    |  Yes  | Unknown |
-|                              [Dogs](https://dog.ceo/dog-api/)                              | Stanford Dogs Dataset 기반          |    No    |  Yes  |   Yes   |
-|                                [HTTPCat](https://http.cat/)                                | 모든 HTTP 상태 코드를 위한 고양이   |    No    |  Yes  | Unknown |
-|                               [HTTP Dogs](https://http.dog/)                               | 모든 HTTP 상태 코드를 위한 개       |    No    |  Yes  | Unknown |
-|                       [Meow Facts](https://meowfacts.herokuapp.com/)                       | 🐈 고양이 팩트를 반환하는 간단한 API |    No    |  Yes  |   No    |
-|                  [Movebank](https://github.com/movebank/movebank-api-doc)                  | 동물의 이동과 마이그레이션 데이터   |    No    |  Yes  | Unknown |
-|                         [Open Dog Registry](https://registry.dog/)                         | 입양                                | `OAuth`  |  Yes  |   Yes   |
-|                 [Petfinder](https://www.petfinder.com/developers/v2/docs/)                 | 개 품종 정보와 이미지               |    No    |  Yes  |   Yes   |
-|                         [RandomDog](https://random.dog/woof.json)                          | 랜덤 개 사진                        |    No    |  Yes  |   Yes   |
-|                          [RandomFox](https://randomfox.ca/floof/)                          | 랜덤 여우 사진                      |    No    |  Yes  |   No    |
-| [RescueGroups](https://userguide.rescuegroups.org/display/APIDG/API+Developers+Guide+Home) | 입양                                |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [AdoptAPet](https://www.adoptapet.com/public/apis/pet_list.html) | 애완동물 입양에 도움이 되는 자료 | `apiKey` | Yes | Yes |
+| [Axolotl](https://theaxolotlapi.netlify.app/) | 아홀로틀(Axolotl) 사진과 사실 모음 | No | Yes | No |
+| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | 매일 새로운 고양이 팩트 | No | Yes | No |
+| [Cat Facts](https://catfact.ninja/) | 무작위 고양이 사실 | No | Yes | Yes |
+| [Cataas](https://cataas.com/) | 고양이 서비스 (고양이 사진과 GIF) | No | Yes | No |
+| [Cats](https://docs.thecatapi.com/) | Tumblr의 고양이 사진 | `apiKey` | Yes | No |
+| [Dog Facts](https://dukengn.github.io/Dog-facts-API/) | 무작위 개 사실 | No | Yes | Yes |
+| [Dog Facts](https://kinduff.github.io/dog-api/) | 개의 무작위 사실 | No | Yes | Yes |
+| [Dogs](https://dog.ceo/dog-api/) | Stanford Dogs Dataset 기반 | No | Yes | Yes |
+| [eBird](https://documenter.getpostman.com/view/664302/S1ENwy59) | 지역 내에서 최근 또는 주목할 만한 조류 관찰을 검색합니다. | `apiKey` | Yes | No |
+| [FishWatch](https://www.fishwatch.gov/developers) | 개별 어종에 대한 정보 및 사진 | No | Yes | Yes |
+| [HTTP Cat](https://http.cat/) | 모든 HTTP 상태 코드를 위한 고양이 | No | Yes | Yes |
+| [HTTP Dog](https://http.dog/) | 모든 HTTP 상태 코드를 위한 개 | No | Yes | Yes |
+| [IUCN](http://apiv3.iucnredlist.org/api/v3/docs) | IUCN 멸종위기종 레드리스트 | `apiKey` | No | No |
+| [MeowFacts](https://github.com/wh-iterabb-it/meowfacts) | 무작위로 고양이에 관한 사실을 알아보세요 | No | Yes | No |
+| [Movebank](https://github.com/movebank/movebank-api-doc) | 동물의 이동과 마이그레이션 데이터 | No | Yes | Yes |
+| [Petfinder](https://www.petfinder.com/developers/) | Petfinder는 애완동물이 입양될 수 있는 또 다른 자원인 집을 찾을 수 있도록 돕는 데 전념하고 있습니다. | `apiKey` | Yes | Yes |
+| [PlaceBear](https://placebear.com/) | 자리 표시자 곰 사진 | No | Yes | Yes |
+| [PlaceDog](https://place.dog) | 자리 표시자 개 사진 | No | Yes | Yes |
+| [PlaceKitten](https://placekitten.com/) | 크기 조정 가능한 새끼고양이 플레이스홀더 이미지 | No | Yes | Yes |
+| [RandomDog](https://random.dog/woof.json) | 랜덤 개 사진 | No | Yes | Yes |
+| [RandomDuck](https://random-d.uk/api) | 오리의 무작위 사진 | No | Yes | No |
+| [RandomFox](https://randomfox.ca/floof/) | 랜덤 여우 사진 | No | Yes | No |
+| [RescueGroups](https://userguide.rescuegroups.org/display/APIDG/API+Developers+Guide+Home) | 입양 | No | Yes | Unknown |
+| [Shibe.Online](http://shibe.online/) | 시바견, 고양이 또는 새의 무작위 사진 | No | Yes | Yes |
+| [The Dog](https://thedogapi.com/) | 멋진 새 앱, 웹사이트 또는 서비스를 만들 때 무료로 사용할 수 있는 개에 관한 모든 공공 서비스 | `apiKey` | Yes | No |
+| [xeno-canto](https://xeno-canto.org/explore/api) | 새 녹음 | No | Yes | Unknown |
+| [Zoo Animals](https://zoo-animal-api.herokuapp.com/) | 동물원 동물에 대한 사실과 사진 | No | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 애니메이션
 
-|                                    API                                    | 설명                                          |   인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------------------------: | --------------------------------------------- | :------: | :---: | :-----: |
-|         [AniList](https://github.com/AniList/ApiV2-GraphQL-Docs)          | 애니메이션 검색 및 추적                       | `OAuth`  |  Yes  | Unknown |
-| [AnimeNewsNetwork](https://www.animenewsnetwork.com/encyclopedia/api.php) | 애니메이션 업계 뉴스                          |    No    |  Yes  |   Yes   |
-|           [AOT quotes](https://attackontitanquotes.vercel.app/)           | 진격의 거인 명대사 API                        |    No    |  Yes  |   Yes   |
-|                        [Jikan](https://jikan.moe)                         | 비공식 MyAnimeList API                        |    No    |  Yes  |   Yes   |
-|          [What Anime](https://soruly.github.io/trace.moe-api/#/)          | 애니메이션 이미지 스캔으로 상세 정보 얻기     | `apiKey` |  Yes  | Unknown |
-|                [Mangadex](https://api.mangadx.org/docs/)                 | 고품질 이미지를 제공하는 광고 없는 만화 리더  |    No    |  Yes  | Unknown |
-|                    [Nekosia API](https://nekosia.cat)                     | 귀여운 랜덤 이미지가 포함된 애니메이션 API    |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [AniAPI](https://aniapi.com/docs/) | 애니메이션 검색, 스트리밍 및 추적기와 동기화 | `OAuth` | Yes | Yes |
+| [AniDB](https://wiki.anidb.net/HTTP_API_Definition) | 애니메이션 데이터베이스 | `apiKey` | No | Unknown |
+| [AniList](https://github.com/AniList/ApiV2-GraphQL-Docs) | 애니메이션 검색 및 추적 | `OAuth` | Yes | Unknown |
+| [AnimeChan](https://github.com/RocktimSaikia/anime-chan) | 애니메이션 인용문(10,000개 이상) | No | Yes | No |
+| [AnimeFacts](https://chandan-02.github.io/anime-facts-rest-api/) | 애니메이션 관련 사실(100개 이상) | No | Yes | Yes |
+| [AnimeNewsNetwork](https://www.animenewsnetwork.com/encyclopedia/api.php) | 애니메이션 업계 뉴스 | No | Yes | Yes |
+| [Catboy](https://catboys.com/api) | Neko 이미지, 재미있는 GIF 등 | No | Yes | Yes |
+| [Danbooru Anime](https://danbooru.donmai.us/wiki_pages/help:api) | 좋은 애니메이션 아트를 찾기 위한 수천 명의 애니메이션 아티스트 데이터베이스 | `apiKey` | Yes | Yes |
+| [Jikan](https://jikan.moe) | 비공식 MyAnimeList API | No | Yes | Yes |
+| [Kitsu](https://kitsu.docs.apiary.io/) | 애니메이션 디스커버리 플랫폼 | `OAuth` | Yes | Yes |
+| [MangaDex](https://api.mangadex.org/docs.html) | 만화 데이터베이스 및 커뮤니티 | `apiKey` | Yes | Unknown |
+| [Mangapi](https://rapidapi.com/pierre.carcellermeunier/api/mangapi3/) | 만화 페이지를 한 언어에서 다른 언어로 번역하세요 | `apiKey` | Yes | Unknown |
+| [MyAnimeList](https://myanimelist.net/clubs.php?cid=13727) | 애니메이션 및 만화 데이터베이스 및 커뮤니티 | `OAuth` | Yes | Unknown |
+| [NekosBest](https://docs.nekos.best) | Neko 이미지 및 애니메이션 롤플레잉 GIF | No | Yes | Yes |
+| [Shikimori](https://shikimori.one/api/doc) | 애니메이션 검색, 추적, 포럼, 요율 | `OAuth` | Yes | Unknown |
+| [Studio Ghibli](https://ghibliapi.herokuapp.com) | 스튜디오 지브리 영화의 리소스 | No | Yes | Yes |
+| [Trace Moe](https://soruly.github.io/trace.moe-api/#/) | 애니메이션 이미지 스캔으로 상세 정보 얻기 | No | Yes | Yes |
+| [Waifu.im](https://waifu.im/docs) | 4000개가 넘는 이미지와 여러 태그로 구성된 아카이브에서 와이푸 사진을 받으세요 | No | Yes | Yes |
+| [Waifu.pics](https://waifu.pics/docs) | 애니메이션 이미지를 위한 이미지 공유 플랫폼 | No | Yes | No |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 안티 멀웨어
 
-|                                  API                                  | 설명                                                                                  |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------------------------: | ------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|               [AbuseIPDB](https://docs.abuseipdb.com/)                | IP/도메인/URL 평판                                                                    | `apiKey` |  Yes  | Unknown |
-|               [Dymo API](https://dymo.tpeoficial.com/)                | 다중 계정 및 사기 탐지. 스팸에 걸리지 않는 이메일 전송                               | `apiKey` |  Yes  |   Yes   |
-|                   [FishFish](https://fishfish.gg/)                    | Discord의 안전성을 향상시키는 리소스와 서비스에 중점을 둔 자원봉사 사이버보안 프로젝트 |    No    |  Yes  | Unknown |
-|   [Google Safe Browse](https://developers.google.com/safe-Browse/)    | Google 링크/도메인 플래깅                                                             | `apiKey` |  Yes  | Unknown |
-|                   [Metacert](https://metacert.com/)                   | Metacert 링크 플래깅                                                                  | `apiKey` |  Yes  | Unknown |
-|              [phish.directory](https://phish.directory/)              | 피싱 링크 및 시도를 포착, 방지, 분류하는 커뮤니티 기반 안티 피싱 도구용 API          | `apiKey` |  Yes  | Unknown |
-| [VirusTotal](https://www.virustotal.com/en/documentation/public-api/) | VirusTotal 파일/URL 분석                                                              | `apiKey` |  Yes  | Unknown |
-|        [Web Of Trust (WOT)](https://www.mywot.com/developers/)        | 웹사이트 평판                                                                         | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [AbuseIPDB](https://docs.abuseipdb.com/) | IP/도메인/URL 평판 | `apiKey` | Yes | Unknown |
+| [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api) | IP/도메인/URL 평판 | `apiKey` | Yes | Unknown |
+| [CAPEsandbox](https://capev2.readthedocs.io/en/latest/usage/api.html) | 악성코드 실행 및 분석 | `apiKey` | Yes | Unknown |
+| [Google Safe Browsing](https://developers.google.com/safe-browsing/) | Google 링크/도메인 신고 | `apiKey` | Yes | Unknown |
+| [MalDatabase](https://maldatabase.com/api-doc.html) | 악성코드 데이터 세트 및 위협 인텔리전스 피드 제공 | `apiKey` | Yes | Unknown |
+| [MalShare](https://malshare.com/doc.php) | 악성코드 아카이브 / 파일 소싱 | `apiKey` | Yes | No |
+| [MalwareBazaar](https://bazaar.abuse.ch/api/) | 악성코드 샘플 수집 및 공유 | `apiKey` | Yes | Unknown |
+| [Metacert](https://metacert.com/) | Metacert 링크 플래깅 | `apiKey` | Yes | Unknown |
+| [NoPhishy](https://rapidapi.com/Amiichu/api/exerra-phishing-check/) | 링크를 확인하여 알려진 피싱 시도인지 확인하세요. | `apiKey` | Yes | Yes |
+| [Phisherman](https://phisherman.gg/) | IP/도메인/URL 평판 | `apiKey` | Yes | Unknown |
+| [Scanii](https://docs.scanii.com/) | 제출된 문서/파일에 위협이 있는지 검사할 수 있는 간단한 REST API | `apiKey` | Yes | Yes |
+| [URLhaus](https://urlhaus-api.abuse.ch/) | 대량 쿼리 및 악성코드 샘플 다운로드 | No | Yes | Yes |
+| [URLScan.io](https://urlscan.io/about-api/) | URL 스캔 및 분석 | `apiKey` | Yes | Unknown |
+| [VirusTotal](https://www.virustotal.com/en/documentation/public-api/) | VirusTotal 파일/URL 분석 | `apiKey` | Yes | Unknown |
+| [Web of Trust](https://support.mywot.com/hc/en-us/sections/360004477734-API-) | IP/도메인/URL 평판 | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 아트 & 디자인
 
-|                                 API                                  | 설명                                                   |   인증   | HTTPS |  CORS   |
-| :------------------------------------------------------------------: | ------------------------------------------------------ | :------: | :---: | :-----: |
-|                [Behance](https://www.behance.net/dev)                | 디자인                                                 | `apiKey` |  Yes  | Unknown |
-|       [Cooper Hewitt](https://collection.cooperhewitt.org/api)       | 스미소니언 디자인 박물관                               | `apiKey` |  Yes  | Unknown |
-|            [Dribbble](http://developer.dribbble.com/v2/)             | 디자인                                                 | `OAuth`  |  No   | Unknown |
-|     [Europeana](https://pro.europeana.eu/resources/apis/search)      | 유럽 박물관 및 갤러리 콘텐츠                           | `apiKey` |  Yes  | Unknown |
-|                  [Freepik](https://freepik.com/api)                  | 스톡 리소스(아이콘, 비디오, 사진), AI 이미지 생성 도구 | `apiKey` |  Yes  | Unknown |
-| [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | 아트                                                   | `apiKey` |  No   | Unknown |
-|            [Iconfinder](https://developer.iconfinder.com)            | 아이콘                                                 | `apiKey` |  Yes  | Unknown |
-|       [Noun Project](http://api.thenounproject.com/index.html)       | 아이콘                                                 | `OAuth`  |  No   | Unknown |
-|           [Rijksmuseum](https://www.rijksmuseum.nl/en/api)           | 아트                                                   | `apiKey` |  Yes  | Unknown |
-|      [Metropolitan Museum of Art](https://metmuseum.github.io/)      | 아트                                                   |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Améthyste](https://api.amethyste.moe/) | Discord 사용자를 위한 이미지 생성 | `apiKey` | Yes | Unknown |
+| [Art Institute of Chicago](https://api.artic.edu/docs/) | 아트 | No | Yes | Yes |
+| [Colormind](http://colormind.io/api-access/) | 색 구성표 생성기 | No | No | Unknown |
+| [ColourLovers](http://www.colourlovers.com/api) | 다양한 패턴, 팔레트, 이미지 얻기 | No | No | Unknown |
+| [Cooper Hewitt](https://collection.cooperhewitt.org/api) | 스미소니언 디자인 박물관 | `apiKey` | Yes | Unknown |
+| [Dribbble](https://developer.dribbble.com) | 세계 최고의 디자이너와 크리에이티브를 만나보세요 | `OAuth` | Yes | Unknown |
+| [EmojiHub](https://github.com/cheatsnake/emojihub) | 카테고리 및 그룹별로 이모티콘 받기 | No | Yes | Yes |
+| [Europeana](https://pro.europeana.eu/resources/apis/search) | 유럽 박물관 및 갤러리 콘텐츠 | `apiKey` | Yes | Unknown |
+| [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | 아트 | `apiKey` | No | Unknown |
+| [Icon Horse](https://icon.horse) | 대체 기능이 포함된 모든 웹사이트의 파비콘 | No | Yes | Yes |
+| [Iconfinder](https://developer.iconfinder.com) | 아이콘 | `apiKey` | Yes | Unknown |
+| [Icons8](https://img.icons8.com/) | 아이콘(페이지에서 "검색 아이콘" 하이퍼링크 찾기) | No | Yes | Unknown |
+| [Lordicon](https://lordicon.com/) | 미리 만들어진 애니메이션이 있는 아이콘 | No | Yes | Yes |
+| [Metropolitan Museum of Art](https://metmuseum.github.io/) | 아트 | No | Yes | No |
+| [Noun Project](http://api.thenounproject.com/index.html) | 아이콘 | `OAuth` | No | Unknown |
+| [PHP-Noise](https://php-noise.com/) | 노이즈 배경 이미지 생성기 | No | Yes | Yes |
+| [Pixel Encounter](https://pixelencounter.com/api) | SVG 아이콘 생성기 | No | Yes | No |
+| [Rijksmuseum](https://data.rijksmuseum.nl/object-metadata/api/) | Rijks박물관 데이터 | `apiKey` | Yes | Unknown |
+| [Word Cloud](https://wordcloudapi.com/) | 쉽게 단어 구름 만들기 | `apiKey` | Yes | Unknown |
+| [xColors](https://x-colors.herokuapp.com/) | 색상 생성 및 변환 | No | Yes | Yes |
+
+**[⬆ 목차로 돌아가기](#목차)**
+
+### 인증 & 권한 부여
+
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Auth0](https://auth0.com) | 구현이 쉽고 적응 가능한 인증 및 권한 부여 플랫폼 | `apiKey` | Yes | Yes |
+| [GetOTP](https://otp.dev/en/docs/) | OTP 흐름을 빠르게 구현 | `apiKey` | Yes | No |
+| [Micro User Service](https://m3o.com/user) | 사용자 관리 및 인증 | `apiKey` | Yes | No |
+| [MojoAuth](https://mojoauth.com) | 안전하고 현대적인 비밀번호 없는 인증 플랫폼 | `apiKey` | Yes | Yes |
+| [SAWO Labs](https://sawolabs.com) | 앱에 비밀번호 없는 인증을 통합하여 로그인을 단순화하고 사용자 경험을 개선하세요. | `apiKey` | Yes | Yes |
+| [Stytch](https://stytch.com/) | 최신 애플리케이션을 위한 사용자 인프라 | `apiKey` | Yes | No |
+| [Warrant](https://warrant.dev/) | 승인 및 액세스 제어를 위한 API | `apiKey` | Yes | Yes |
+
+**[⬆ 목차로 돌아가기](#목차)**
+
+### 블록체인
+
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Bitquery](https://graphql.bitquery.io/ide) | 온체인 GraphQL API 및 DEX API | `apiKey` | Yes | Yes |
+| [Chainlink](https://chain.link/developer-resources) | Chainlink로 하이브리드 스마트 계약 구축 | No | Yes | Unknown |
+| [Chainpoint](https://tierion.com/chainpoint/) | 데이터를 비트코인 블록체인에 고정하기 위한 글로벌 네트워크 | No | Yes | Unknown |
+| [Covalent](https://www.covalenthq.com/docs/api/) | 멀티 블록체인 데이터 집계자 | `apiKey` | Yes | Unknown |
+| [Etherscan](https://etherscan.io/apis) | 이더리움 탐색기 API | `apiKey` | Yes | Yes |
+| [Helium](https://docs.helium.com/api/blockchain/introduction/) | Helium은 공공 장거리 무선 범위를 생성하는 글로벌 분산형 핫스팟 네트워크입니다. | No | Yes | Unknown |
+| [Nownodes](https://nownodes.io/) | API를 통해 고품질 연결을 제공하는 서비스로서의 블록체인 솔루션 | `apiKey` | Yes | Unknown |
+| [Steem](https://developers.steem.io/) | 블록체인 기반 블로그 및 소셜 미디어 웹사이트 | No | No | No |
+| [The Graph](https://thegraph.com) | GraphQL을 사용하여 Ethereum과 같은 네트워크를 쿼리하기 위한 인덱싱 프로토콜 | `apiKey` | Yes | Unknown |
+| [Walltime](https://walltime.info/api.html) | Walltime의 시장 정보를 검색하려면 | No | Yes | Unknown |
+| [Watchdata](https://docs.watchdata.io) | Ethereum 블록체인에 대한 간단하고 안정적인 API 액세스 제공 | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 도서
 
-|                                    API                                    | 설명                                                              |  인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------------------------: | ----------------------------------------------------------------- | :-----: | :---: | :-----: |
-|               [Bhagavad Gita](https://bhagavadgita.io/api)                | 바가바드 기타 텍스트                                              | `OAuth` |  Yes  |   Yes   |
-|           [Google Books](https://developers.google.com/books/)            | 도서                                                              | `OAuth` |  Yes  | Unknown |
-|        [Harry Potter API](https://github.com/fedeperin/potterapi)         | 해리포터 책, 영화, 캐릭터, 마법 주문 데이터 API                   |   No    |  Yes  |   Yes   |
-|          [Open Library](https://openlibrary.org/developers/api)           | 도서, 도서 표지 및 관련 데이터                                    |   No    |  Yes  | Unknown |
-| [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | 도서, 도서 표지 및 관련 데이터                                    |   No    |  Yes  | Unknown |
-|            [Rig Veda](https://aninditabasu.github.io/indica/)             | 신과 시인, 범주, 운율과 함께 만달과 수크타 번호                   |   No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [A Bíblia Digital](https://www.abibliadigital.com.br/en) | 여러 버전의 성경을 관리하는 것에 대해 걱정하지 마세요 | `apiKey` | Yes | No |
+| [Bhagavad Gita](https://docs.bhagavadgitaapi.in) | 21명 이상의 저자가 산스크리트어/영어/힌디어로 번역한 오픈 소스 Shrimad Bhagavad Gita API | `apiKey` | Yes | Yes |
+| [Bhagavad Gita](https://bhagavadgita.io/api) | 바가바드 기타 텍스트 | `OAuth` | Yes | Yes |
+| [Bhagavad Gita telugu](https://gita-api.vercel.app) | 텔루구어 및 odia 언어로 된 Bhagavad Gita API | No | Yes | Yes |
+| [Bible-api](https://bible-api.com/) | 여러 언어를 지원하는 무료 성경 API | No | Yes | Yes |
+| [British National Bibliography](http://bnb.data.bl.uk/) | 도서 | No | No | Unknown |
+| [Crossref Metadata Search](https://github.com/CrossRef/rest-api-doc) | 도서 및 기사 메타데이터 | No | Yes | Unknown |
+| [Ganjoor](https://api.ganjoor.net) | 관련 원고, 낭송 및 음악 트랙에 대한 액세스를 포함한 고전 페르시아 시 작품 | `OAuth` | Yes | Yes |
+| [Google Books](https://developers.google.com/books/) | 도서 | `OAuth` | Yes | Unknown |
+| [GurbaniNow](https://github.com/GurbaniNow/api) | 빠르고 정확한 Gurbani RESTful API | No | Yes | Unknown |
+| [Gutendex](https://gutendex.com/) | Project Gutenberg Books Library에서 데이터를 가져오기 위한 웹 API | No | Yes | Unknown |
+| [Open Library](https://openlibrary.org/developers/api) | 도서, 도서 표지 및 관련 데이터 | No | Yes | No |
+| [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | 도서, 도서 표지 및 관련 데이터 | No | Yes | Yes |
+| [PoetryDB](https://github.com/thundercomb/poetrydb#readme) | 방대한 시 컬렉션에서 즉각적인 데이터를 얻을 수 있습니다. | No | Yes | Yes |
+| [Quran](https://quran.api-docs.io/) | 여러 언어를 지원하는 RESTful Quran API | No | Yes | Yes |
+| [Quran Cloud](https://alquran.cloud/api) | Ayah, Surah, Juz 또는 전체 꾸란을 검색하는 RESTful Quran API | No | Yes | Yes |
+| [Quran-api](https://github.com/fawazahmed0/quran-api#readme) | 90개 이상의 언어와 400개 이상의 번역이 포함된 무료 Quran API 서비스 | No | Yes | Yes |
+| [Rig Veda](https://aninditabasu.github.io/indica/html/rv.html) | 만달과 숙타 수를 포함한 신과 시인, 그들의 범주, 운문 미터 | No | Yes | Unknown |
+| [Runyankole Bible](https://runyankole-bible-api.vercel.app) | Runyankore-Rukiga 성경용 무료 REST API — 66권, 31106절 | No | Yes | Yes |
+| [The Bible](https://docs.api.bible) | 성경에서 필요한 모든 것을 검색 가능한 한 곳에 | `apiKey` | Yes | Unknown |
+| [Thirukkural](https://api-thirukkural.web.app/) | 1330년 티루쿠랄 시와 타밀어 및 영어 설명 | No | Yes | Yes |
+| [Urantia Papers](https://urantia.dev) | 오디오 내레이션, 개체, 번역이 포함된 유란시아 문서 전체에 대한 전체 텍스트 + 의미 검색 | No | Yes | Yes |
+| [Vedic Society](https://aninditabasu.github.io/indica/html/vs.html) | 베다 문헌에 나오는 모든 명사(이름, 장소, 동물, 사물)에 대한 설명 | No | Yes | Unknown |
+| [Wizard World](https://wizard-world-api.herokuapp.com/swagger/index.html) | 해리포터 세계에서 정보를 얻으세요 | No | Yes | Yes |
+| [Wolne Lektury](https://wolnelektury.pl/api/) | WolneLektury.pl 웹사이트에서 제공되는 전자책에 대한 정보를 얻기 위한 API | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 비즈니스
 
-|                                    API                                     | 설명                                                        |   인증   | HTTPS |  CORS   |
-| :------------------------------------------------------------------------: | ----------------------------------------------------------- | :------: | :---: | :-----: |
-|             [Charity Search](http://charityapi.orghunter.com/)             | 비영리 자선단체 데이터                                      | `apiKey` |  No   | Unknown |
-|            [Clearbit Logo](https://clearbit.com/docs#logo-api)             | 회사 로고 검색 및 프로젝트에 임베딩                         | `apiKey` |  Yes  | Unknown |
-|                 [Domainsdb.info](https://domainsdb.info/)                  | 등록된 도메인 이름 검색                                     |    No    |  Yes  | Unknown |
-|                      [Favicon.im](https://favicon.im)                      | 모든 웹사이트의 파비콘을 즉시 가져와서 표시                 |    No    |  Yes  |   No    |
-|              [Freelancer](https://developers.freelancer.com)               | 프리랜서를 고용하여 작업 완료                               | `OAuth`  |  Yes  | Unknown |
-|             [Gmail](https://developers.google.com/gmail/api/)              | 사용자 받은편지함에 대한 유연한 RESTful 액세스              | `OAuth`  |  Yes  | Unknown |
-|        [Google Analytics](https://developers.google.com/analytics/)        | 올바른 타겟층에 도달하기 위한 데이터 수집, 구성 및 분석     | `OAuth`  |  Yes  | Unknown |
-|                       [LogoKit](https://logokit.com)                       | 브랜드, 주식, 암호화폐용 로고 API                           | `apiKey` |  Yes  | Unknown |
-| [MailboxValidator](https://www.mailboxvalidator.com/api-single-validation) | 전달 가능성 향상을 위한 이메일 주소 검증                    | `apiKey` |  Yes  | Unknown |
-|                    [mailgun](https://www.mailgun.com/)                     | 이메일 서비스                                               | `apiKey` |  Yes  | Unknown |
-|                    [Mailjet](https://www.mailjet.com/)                     | 이메일 서비스                                               | `apiKey` |  Yes  | Unknown |
-|                   [markerapi](http://www.markerapi.com/)                   | 상표 검색                                                   |    No    |  No   | Unknown |
-|                  [Trello](https://developers.trello.com/)                  | 프로젝트 정리 및 우선순위 설정을 위한 보드, 목록, 카드      | `OAuth`  |  Yes  | Unknown |
-|                  [Tomba Email finder](https://tomba.io/)                   | B2B 영업 및 이메일 마케팅을 위한 이메일 파인더              | `apiKey` |  Yes  |   Yes   |
-|                    [Clientsbee](https://clientsbee.com)                    | 비즈니스를 위한 무료 리드 및 기술적 데이터                  | `apikey` |  Yes  |   No    |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Apache Superset](https://superset.apache.org/docs/api) | Superset에서 BI 대시보드 및 데이터 소스를 관리하는 API | `apiKey` | Yes | Yes |
+| [Charity Search](http://charityapi.orghunter.com/) | 비영리 자선단체 데이터 | `apiKey` | No | Unknown |
+| [Clearbit Logo](https://clearbit.com/docs#logo-api) | 회사 로고 검색 및 프로젝트에 임베딩 | `apiKey` | Yes | Unknown |
+| [Domainsdb.info](https://domainsdb.info/) | 등록된 도메인 이름 검색 | No | Yes | No |
+| [Freelancer](https://developers.freelancer.com) | 프리랜서를 고용하여 작업 완료 | `OAuth` | Yes | Unknown |
+| [Gmail](https://developers.google.com/gmail/api/) | 사용자 받은편지함에 대한 유연한 RESTful 액세스 | `OAuth` | Yes | Unknown |
+| [Google Analytics](https://developers.google.com/analytics/) | 올바른 타겟층에 도달하기 위한 데이터 수집, 구성 및 분석 | `OAuth` | Yes | Unknown |
+| [Instatus](https://instatus.com/help/api) | HTTP REST API를 통해 상태 페이지에 유지 관리 및 인시던트를 게시하고 업데이트합니다. | `apiKey` | Yes | Unknown |
+| [Mailchimp](https://mailchimp.com/developer/) | 마케팅 캠페인 및 거래 메일 보내기 | `apiKey` | Yes | Unknown |
+| [mailjet](https://www.mailjet.com/) | 이메일 서비스 | `apiKey` | Yes | Unknown |
+| [markerapi](https://markerapi.com) | 상표 검색 | No | No | Unknown |
+| [ORB Intelligence](https://api.orb-intelligence.com/docs/) | 회사 조회 | `apiKey` | Yes | Unknown |
+| [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Redash에서 쿼리 및 대시보드에 액세스하세요. | `apiKey` | Yes | Yes |
+| [Smartsheet](https://smartsheet.redoc.ly/) | 프로그래밍 방식으로 스마트시트 데이터 및 계정 정보에 액세스할 수 있습니다. | `OAuth` | Yes | No |
+| [Square](https://developer.squareup.com/reference/square) | 결제를 받고, 환불을 관리하고, 고객이 온라인으로 결제하도록 돕는 간편한 방법 | `OAuth` | Yes | Unknown |
+| [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban 소프트웨어, 작업 시각화, 조직 리드 타임, 처리량 및 생산성 향상 | `apiKey` | Yes | Unknown |
+| [Tenders in Hungary](https://tenders.guru/hu/api) | JSON 형식으로 헝가리 조달 데이터 가져오기 | No | Yes | Unknown |
+| [Tenders in Poland](https://tenders.guru/pl/api) | JSON 형식으로 폴란드 조달 데이터 가져오기 | No | Yes | Unknown |
+| [Tenders in Romania](https://tenders.guru/ro/api) | JSON 형식으로 루마니아 조달 데이터 가져오기 | No | Yes | Unknown |
+| [Tenders in Spain](https://tenders.guru/es/api) | JSON 형식으로 스페인 조달 데이터 가져오기 | No | Yes | Unknown |
+| [Tenders in Ukraine](https://tenders.guru/ua/api) | JSON 형식으로 우크라이나 조달 데이터 가져오기 | No | Yes | Unknown |
+| [Tomba email finder](https://tomba.io/api) | B2B 판매 및 이메일 마케팅을 위한 이메일 찾기 및 이메일 검증기 | `apiKey` | Yes | Yes |
+| [Trello](https://developers.trello.com/) | 프로젝트 정리 및 우선순위 설정을 위한 보드, 목록, 카드 | `OAuth` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 캘린더
 
-|                                       API                                       | 설명                                                                                    |   인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------------------------------: | --------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|       [Abstract's Holiday API](https://www.abstractapi.com/holidays-api)        | 120개 이상 국가의 100년 이상의 국가, 지역, 종교 휴일                                    | `apiKey` |  Yes  |   Yes   |
-| [Byabbe](https://byabbe.se/on-this-day/#/default/get__month___day__events_json) | 특정 날짜의 위키피디아 역사 검색                                                        |    No    |  Yes  | Unknown |
-|                [Calendar Index](https://www.calendarindex.com/)                 | 전 세계 휴일 및 근무일                                                                  | `apiKey` |  Yes  |   Yes   |
-|              [Czech Namedays Calendar](http://svatky.adresa.info/)              | 이름을 조회하여 이름 축일 날짜 반환                                                     |    No    |  No   | Unknown |
-|     [Google Calendar](https://developers.google.com/google-apps/calendar/)      | Google 캘린더 이벤트 표시, 생성 및 수정                                                 | `OAuth`  |  Yes  | Unknown |
-|          [Hebrew Calendar](https://www.hebcal.com/home/developer-apis)          | 그레고리력과 히브리력 간 변환, 안식일과 휴일 시간 조회 등                               |    No    |  No   | Unknown |
-|                       [Holidays](https://holidayapi.com/)                       | 휴일에 대한 역사적 데이터                                                               | `apiKey` |  Yes  | Unknown |
-|                     [Non-working Days](https://isdayoff.ru)                     | 러시아, 우크라이나, 벨라루스, 카자흐스탄의 근무일, 비근무일, 단축근무일 확인 간단한 API |    No    |  Yes  |   Yes   |
-|                       [Nager.Date](https://date.nager.at)                       | 90개 이상 국가의 공휴일                                                                 |    No    |  Yes  |   No    |
-|                  [Namedays Calendar](https://api.abalin.net/)                   | 여러 국가의 이름 축일 제공                                                              |    No    |  Yes  |   Yes   |
-|               [Non-Working Days](https://github.com/gadael/icsdb)               | 비근무일을 위한 ICS 파일 데이터베이스                                                   |    No    |  Yes  | Unknown |
-|              [OpenHolidays API](https://www.openholidaysapi.org/)               | 개방형 REST API를 통한 많은 국가의 공휴일 및 학교 휴일                                  |    No    |  Yes  |   Yes   |
-|            [Russian Calendar](https://github.com/egno/work-calendar)            | 날짜가 러시아 휴일인지 확인                                                             |    No    |  Yes  |   No    |
-|      [TimeZones iCal Library](https://tz.add-to-calendar-technology.com/)       | 공식 시간대 및 해당 iCal VTIMEZONE 블록 데이터베이스                                    |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Calendarific](https://calendarific.com/) | 전세계 공휴일 | `apiKey` | Yes | Unknown |
+| [Checkiday - National Holiday API](https://apilayer.com/marketplace/checkiday-api) | 업계 최고의 Holiday API. 5,000개가 넘는 공휴일과 수천 개의 설명이 있습니다. 세계 최고의 기업들이 신뢰하는 | `apiKey` | Yes | Unknown |
+| [Church Calendar](http://calapi.inadiutorium.cz/) | 가톨릭 전례력 | No | No | Unknown |
+| [Czech Namedays Calendar](https://svatky.adresa.info) | 이름을 검색하고 이름의 날짜를 반환합니다. | No | No | Unknown |
+| [Festivo Public Holidays](https://docs.getfestivo.com/docs/products/public-holidays-api/intro) | 시중에서 가장 빠르고 진보된 공휴일 및 준수 서비스 | `apiKey` | Yes | Yes |
+| [Google Calendar](https://developers.google.com/google-apps/calendar/) | Google 캘린더 이벤트 표시, 생성 및 수정 | `OAuth` | Yes | Unknown |
+| [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | 그레고리력과 히브리력 간 변환, 안식일과 휴일 시간 조회 등 | No | No | Unknown |
+| [Holidays](https://holidayapi.com/) | 휴일에 대한 역사적 데이터 | `apiKey` | Yes | Unknown |
+| [LectServe](http://www.lectserve.com) | 개신교 전례 달력 | No | No | Unknown |
+| [Nager.Date](https://date.nager.at) | 90개 이상 국가의 공휴일 | No | Yes | No |
+| [Namedays Calendar](https://nameday.abalin.net) | 여러 국가의 이름일 제공 | No | Yes | Yes |
+| [Non-Working Days](https://github.com/gadael/icsdb) | 비근무일을 위한 ICS 파일 데이터베이스 | No | Yes | Unknown |
+| [Non-Working Days](https://isdayoff.ru) | 러시아, 우크라이나, 벨라루스, 카자흐스탄의 근무일, 비근무일, 단축근무일 확인 간단한 API | No | Yes | Yes |
+| [Public Holidays](https://www.abstractapi.com/holidays-api) | 120개 이상 국가의 100년 이상의 국가, 지역, 종교 휴일 | `apiKey` | Yes | Yes |
+| [Russian Calendar](https://github.com/egno/work-calendar) | 날짜가 러시아 휴일인지 확인 | No | Yes | No |
+| [UK Bank Holidays](https://www.gov.uk/bank-holidays.json) | 잉글랜드, 웨일스, 스코틀랜드, 북아일랜드의 은행 휴무일 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 클라우드 스토리지 & 파일 공유
 
-|                         API                          | 설명                     |   인증   | HTTPS |  CORS   |
-| :--------------------------------------------------: | ------------------------ | :------: | :---: | :-----: |
-|     [AnonFiles](https://anonfiles.com/docs/api)      | 파일 공유 및 저장        |    No    |  Yes  | Unknown |
-|          [Box](https://developer.box.com/)           | 파일 공유 및 저장        | `OAuth`  |  Yes  | Unknown |
-|    [Dropbox](https://www.dropbox.com/developers)     | 파일 공유 및 저장        | `OAuth`  |  Yes  | Unknown |
-| [Google Drive](https://developers.google.com/drive/) | 파일 공유 및 저장        | `OAuth`  |  Yes  | Unknown |
-|        [OneDrive](https://dev.onedrive.com/)         | 파일 공유 및 저장        | `OAuth`  |  Yes  | Unknown |
-|        [Pastebin](https://pastebin.com/api/)         | 일반 텍스트 저장         | `apiKey` |  Yes  | Unknown |
-|   [WeTransfer](https://developers.wetransfer.com)    | 파일 공유                | `apiKey` |  Yes  |   Yes   |
-|        [Mega.nz](https://mega.io/developers)         | 파일 공유 및 저장        |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [AnonFiles](https://anonfiles.com/docs/api) | 파일 공유 및 저장 | No | Yes | Unknown |
+| [BayFiles](https://bayfiles.com/docs/api) | 파일 업로드 및 공유 | No | Yes | Unknown |
+| [Box](https://developer.box.com/) | 파일 공유 및 저장 | `OAuth` | Yes | Unknown |
+| [ddownload](https://ddownload.com/api) | 파일 공유 및 저장 | `apiKey` | Yes | Unknown |
+| [Dropbox](https://www.dropbox.com/developers) | 파일 공유 및 저장 | `OAuth` | Yes | Unknown |
+| [File.io](https://www.file.io) | 파일 공유 | No | Yes | Unknown |
+| [Filestack](https://www.filestack.com) | Filestack 파일 업로더 및 파일 업로드 API | `apiKey` | Yes | Unknown |
+| [FileUp](https://github.com/RealSinaSnp/FileUp) | 업로드 API, 만료 시간 및 보기 제한을 갖춘 임시 파일 호스팅 | No | Yes | Unknown |
+| [GoFile](https://gofile.io/api) | 무제한 크기의 파일을 무료로 업로드 | `apiKey` | Yes | Unknown |
+| [Google Drive](https://developers.google.com/drive/) | 파일 공유 및 저장 | `OAuth` | Yes | Unknown |
+| [Gyazo](https://gyazo.com/api/docs) | 이미지 업로드 | `apiKey` | Yes | Unknown |
+| [Imgbb](https://api.imgbb.com/) | 간단하고 빠른 비공개 이미지 공유 | `apiKey` | Yes | Unknown |
+| [OneDrive](https://developer.microsoft.com/onedrive) | 파일 공유 및 저장 | `OAuth` | Yes | Unknown |
+| [Pantry](https://getpantry.cloud/) | 소규모 프로젝트를 위한 무료 JSON 스토리지 | No | Yes | Yes |
+| [Pastebin](https://pastebin.com/doc_api) | 일반 텍스트 저장소 | `apiKey` | Yes | Unknown |
+| [Pinata](https://docs.pinata.cloud/) | IPFS 고정 서비스 API | `apiKey` | Yes | Unknown |
+| [Quip](https://quip.com/dev/automation/documentation) | 그룹을 위한 파일 공유 및 저장 | `apiKey` | Yes | Yes |
+| [Storj](https://docs.storj.io/dcs/) | 분산형 오픈 소스 클라우드 스토리지 | `apiKey` | Yes | Unknown |
+| [The Null Pointer](https://0x0.st) | 헛소리 없는 파일 호스팅 및 URL 단축 서비스 | No | Yes | Unknown |
+| [Web3 Storage](https://web3.storage/) | 1TB 공간으로 무료로 파일 공유 및 저장 가능 | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 지속적 통합
 
-|                      API                      | 설명                                                            |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------: | --------------------------------------------------------------- | :------: | :---: | :-----: |
-| [CircleCI](https://circleci.com/docs/api/v2/) | 지속적 통합 및 지속적 배포를 사용한 소프트웨어 개발 프로세스 자동화 | `apiKey` |  Yes  | Unknown |
-|   [Codeship](https://apidocs.codeship.com/)   | 클라우드의 지속적 통합 플랫폼                                   | `apiKey` |  Yes  | Unknown |
-| [Travis CI](https://docs.travis-ci.com/api/)  | GitHub 프로젝트를 Travis CI와 동기화하여 몇 분 만에 코드 테스트 | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Azure DevOps Health](https://docs.microsoft.com/en-us/rest/api/resourcehealth) | 리소스 상태는 Azure 문제가 리소스에 영향을 미칠 때 진단하고 지원을 받는 데 도움이 됩니다. | `apiKey` | No | No |
+| [Bitrise](https://api-docs.bitrise.io/) | 도구 및 프로세스 통합을 구축하여 효율적인 개발 파이프라인 생성 | `apiKey` | Yes | Unknown |
+| [Buddy](https://buddy.works/docs/api/getting-started/overview) | 가장 빠른 지속적 통합 및 지속적 전달 플랫폼 | `OAuth` | Yes | Unknown |
+| [CircleCI](https://circleci.com/docs/api/v1-reference/) | 지속적인 통합과 지속적인 전달을 사용하여 소프트웨어 개발 프로세스를 자동화합니다. | `apiKey` | Yes | Unknown |
+| [Codeship](https://docs.cloudbees.com/docs/cloudbees-codeship/latest/api-overview/) | Codeship은 클라우드의 지속적인 통합 플랫폼입니다. | `apiKey` | Yes | Unknown |
+| [Travis CI](https://docs.travis-ci.com/api/) | GitHub 프로젝트를 Travis CI와 동기화하여 몇 분 만에 코드 테스트 | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 암호화폐
 
-|                                   API                                    | 설명                                                                                                  |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------------------------------: | ----------------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-| [Binance](https://github.com/binance-exchange/binance-official-api-docs) | 중국 기반 암호화폐 거래소                                                                             | `apiKey` |  Yes  | Unknown |
-|                     [Bitquery](https://bitquery.io/)                     | 40개 이상 체인을 위한 실시간 스트리밍 API, NFT API, 자금 흐름 조사 도구를 제공하는 블록체인 데이터     | `apiKey` |  Yes  | Unknown |
-|           [BitcoinAverage](https://apiv2.bitcoinaverage.com/)            | 블록체인 업계를 위한 디지털 자산 가격 데이터                                                          | `apiKey` |  Yes  | Unknown |
-|       [BitcoinCharts](https://bitcoincharts.com/about/exchanges/)        | 비트코인 네트워크 관련 금융 및 기술 데이터                                                            |    No    |  Yes  | Unknown |
-|             [Bitmex](https://www.bitmex.com/app/apiOverview)             | 홍콩 기반 실시간 암호화폐 파생상품 거래 플랫폼                                                        | `apiKey` |  Yes  | Unknown |
-|                 [Bithumb](https://apidocs.bithumb.com/)                  | 암호화폐 거래 플랫폼                                                                                  | `apiKey` |  Yes  | Unknown |
-|                 [Block](https://www.block.io/docs/basic)                 | 비트코인 결제, 지갑 및 거래 데이터                                                                    | `apiKey` |  Yes  | Unknown |
-|              [Blockchain](https://www.blockchain.info/api)               | 비트코인 결제, 지갑 및 거래 데이터                                                                    |    No    |  Yes  | Unknown |
-|                   [BlockFacts](https://blockfacts.io/)                   | 단일 통합 API를 통한 여러 거래소의 실시간 암호화폐 데이터 등                                          | `apiKey` |  Yes  | Unknown |
-|                   [CoinAPI](https://docs.coinapi.io/)                    | 단일 API 하에 통합된 모든 통화 거래소                                                                 | `apiKey` |  Yes  |   No    |
-|               [Coinbase](https://developers.coinbase.com)                | 비트코인, 비트코인 캐시, 라이트코인, 이더리움 가격                                                    | `apiKey` |  Yes  | Unknown |
-|            [Coinbase Pro](https://docs.pro.coinbase.com/#api)            | 암호화폐 거래 플랫폼                                                                                  | `apiKey` |  Yes  | Unknown |
-|                 [CoinDesk](http://www.coindesk.com/api/)                 | 비트코인 가격 지수                                                                                    |    No    |  No   | Unknown |
-|                [CoinGecko](http://www.coingecko.com/api)                 | 암호화폐 가격, 시장, 개발자/소셜 데이터                                                               | `apiKey` |  Yes  |   Yes   |
-|                [Coinigy](https://coinigy.docs.apiary.io)                 | Coinigy 계정 및 거래소와 직접 상호작용                                                                | `apiKey` |  Yes  | Unknown |
-|                    [CoinLayer](https://coinlayer.com)                    | 실시간 암호화폐 환율                                                                                  | `apiKey` |  Yes  | Unknown |
-|                  [Coinlib](https://coinlib.io/apidocs)                   | 암호화폐 가격                                                                                         | `apiKey` |  Yes  | Unknown |
-|       [Coinlore](https://www.coinlore.com/cryptocurrency-data-api)       | 암호화폐 가격, 거래량 등                                                                              |    No    |  Yes  | Unknown |
-|             [CoinMarketCap](https://coinmarketcap.com/api/)              | 암호화폐 가격                                                                                         | `apiKey` |  Yes  | Unknown |
-|                [Coinpaprika](https://api.coinpaprika.com)                | 암호화폐 가격, 거래량 등                                                                              |    No    |  Yes  |   Yes   |
-|               [CoinRanking](https://docs.coinranking.com/)               | 실시간 암호화폐 데이터                                                                                |    No    |  Yes  | Unknown |
-|             [Covalent](https://www.covalenthq.com/docs/api/)             | 멀티 블록체인 데이터 집계자                                                                           |   Yes    |  Yes  | Unknown |
-|           [CryptoCompare](https://www.cryptocompare.com/api#)            | 암호화폐 비교                                                                                         |    No    |  Yes  | Unknown |
-|             [Cryptonator](https://www.cryptonator.com/api/)              | 암호화폐 환율                                                                                         |    No    |  Yes  | Unknown |
-|                  [CurrencyAPI](https://currencyapi.com)                  | 환율 변환 API                                                                                         | `apiKey` |  Yes  | Unknown |
-|                   [Gates.io](https://www.gate.io/api2)                   | 블록체인 자산 거래소                                                                                  |    No    |  Yes  | Unknown |
-|               [Gemini](https://docs.gemini.com/rest-api/)                | 암호화폐 거래소                                                                                       |    No    |  Yes  | Unknown |
-|               [MEXC Global](https://www.mexc.com/mexc-api)               | 거래 마켓플레이스를 위한 암호화 자산 거래소                                                           | `apiKey` |  Yes  | Unknown |
-|             [Nexchange](https://nexchange2.docs.apiary.io/)              | 자동화된 암호화폐 거래소 서비스                                                                       |    No    |  No   |   Yes   |
-|                  [NiceHash](https://docs.nicehash.com/)                  | 최대 암호화폐 마이닝 마켓플레이스                                                                     | `apiKey` |  Yes  | Unknown |
-|              [Poloniex](https://api-docs.poloniex.com/spot)              | 미국 기반 디지털 자산 거래소                                                                          | `apiKey` |  Yes  | Unknown |
-|       [WorldCoinIndex](https://www.worldcoinindex.com/apiservice)        | 암호화폐 가격                                                                                         | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Coinlayer](https://coinlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 실시간 암호화폐 환율 | `apiKey` | Yes | Unknown |
+| [0x](https://0x.org/api) | 다양한 유동성 풀에서 토큰 및 풀 통계를 쿼리하기 위한 API | No | Yes | Yes |
+| [1inch](https://1inch.io/api/) | 탈중앙화 거래소 쿼리를 위한 API | No | Yes | Unknown |
+| [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | 이더리움 노드 서비스 제공자 | `apiKey` | Yes | Yes |
+| [Alpha (Mossland)](https://alpha.moss.land/developers) | 한국 암호화폐 채널 입장 + RAG Q&A + 정식 엔터티/주제/이벤트 스토어 | No | Yes | Yes |
+| [Binance](https://github.com/binance/binance-spot-api-docs) | 중국에 기반을 둔 암호화폐 거래를 위한 거래소 | `apiKey` | Yes | Unknown |
+| [Bitcambio](https://nova.bitcambio.com.br/api/v3/docs#a-public) | 거래소에서 거래되는 모든 자산 목록을 가져옵니다. | No | Yes | Unknown |
+| [BitcoinAverage](https://apiv2.bitcoinaverage.com/) | 블록체인 업계를 위한 디지털 자산 가격 데이터 | `apiKey` | Yes | Unknown |
+| [BitcoinCharts](https://bitcoincharts.com/about/exchanges/) | 비트코인 네트워크 관련 금융 및 기술 데이터 | No | Yes | Unknown |
+| [Bitfinex](https://docs.bitfinex.com/docs) | 암호화폐 거래 플랫폼 | `apiKey` | Yes | Unknown |
+| [Bitmex](https://www.bitmex.com/app/apiOverview) | 홍콩 기반 실시간 암호화폐 파생상품 거래 플랫폼 | `apiKey` | Yes | Unknown |
+| [Bittrex](https://bittrex.github.io/api/v3) | 차세대 암호화폐 거래 플랫폼 | `apiKey` | Yes | Unknown |
+| [Block](https://block.io/docs/basic) | 비트코인 결제, 지갑 및 거래 데이터 | `apiKey` | Yes | Unknown |
+| [Blockchain](https://www.blockchain.com/api) | 비트코인 결제, 지갑 및 거래 데이터 | `apiKey` | Yes | Unknown |
+| [blockfrost Cardano](https://blockfrost.io/) | Cardano 메인넷 및 여러 테스트넷과의 상호 작용 | `apiKey` | Yes | Unknown |
+| [Brave NewCoin](https://bravenewcoin.com/developers) | 200개가 넘는 거래소의 실시간 및 과거 암호화폐 데이터 | `apiKey` | Yes | Unknown |
+| [BtcTurk](https://docs.btcturk.com/) | 구매 및 판매가 가능한 실시간 암호화폐 데이터, 그래프 및 API | `apiKey` | Yes | Yes |
+| [Bybit](https://bybit-exchange.github.io/docs/linear/#t-introduction) | 암호화폐 데이터 피드 및 알고리즘 거래 | `apiKey` | Yes | Unknown |
+| [CoinAPI](https://docs.coinapi.io/) | 단일 API 하에 통합된 모든 통화 거래소 | `apiKey` | Yes | No |
+| [Coinbase](https://developers.coinbase.com) | 비트코인, 비트코인 캐시, 라이트코인, 이더리움 가격 | `apiKey` | Yes | Unknown |
+| [Coinbase Pro](https://docs.pro.coinbase.com/#api) | 암호화폐 거래 플랫폼 | `apiKey` | Yes | Unknown |
+| [CoinCap](https://docs.coincap.io/) | RESTful API를 통한 실시간 암호화폐 가격 | No | Yes | Unknown |
+| [CoinDCX](https://docs.coindcx.com/) | 암호화폐 거래 플랫폼 | `apiKey` | Yes | Unknown |
+| [CoinDesk](https://old.coindesk.com/coindesk-api/) | 여러 통화로 표시되는 CoinDesk의 비트코인 ​​가격 지수(BPI) | No | Yes | Unknown |
+| [CoinGecko](http://www.coingecko.com/api) | 암호화폐 가격, 시장, 개발자/소셜 데이터 | No | Yes | Yes |
+| [Coinigy](https://coinigy.docs.apiary.io) | Coinigy 계정 및 거래소와 직접 상호작용 | `apiKey` | Yes | Unknown |
+| [Coinlib](https://coinlib.io/apidocs) | 암호화폐 가격 | `apiKey` | Yes | Unknown |
+| [Coinlore](https://www.coinlore.com/cryptocurrency-data-api) | 암호화폐 가격, 거래량 등 | No | Yes | Unknown |
+| [CoinMarketCap](https://coinmarketcap.com/api/) | 암호화폐 가격 | `apiKey` | Yes | Unknown |
+| [Coinpaprika](https://api.coinpaprika.com) | 암호화폐 가격, 거래량 등 | No | Yes | Yes |
+| [CoinRanking](https://developers.coinranking.com/api/documentation) | 실시간 암호화폐 데이터 | `apiKey` | Yes | Unknown |
+| [Coinremitter](https://coinremitter.com/docs) | 암호화폐 결제 및 가격 | `apiKey` | Yes | Unknown |
+| [CoinStats](https://documenter.getpostman.com/view/5734027/RzZ6Hzr3?version=latest) | 암호화폐 추적기 | No | Yes | Unknown |
+| [CryptAPI](https://docs.cryptapi.io/) | 암호화폐 결제 프로세서 | No | Yes | Unknown |
+| [CryptingUp](https://www.cryptingup.com/apidoc/#introduction) | 암호화폐 데이터 | No | Yes | Unknown |
+| [CryptoCompare](https://www.cryptocompare.com/api#) | 암호화폐 비교 | No | Yes | Unknown |
+| [CryptoMarket](https://api.exchange.cryptomkt.com/) | 암호화폐 거래 플랫폼 | `apiKey` | Yes | Yes |
+| [Cryptonator](https://www.cryptonator.com/api/) | 암호화폐 환율 | No | Yes | Unknown |
+| [dYdX](https://docs.dydx.exchange/) | 분산형 암호화폐 거래소 | `apiKey` | Yes | Unknown |
+| [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | 이더리움 토큰, 잔액, 주소, 거래 내역, 계약 및 사용자 정의 구조 | `apiKey` | Yes | Unknown |
+| [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | 영국에 본사를 둔 암호화폐 거래소 | `apiKey` | Yes | Unknown |
+| [FTX](https://docs.ftx.com/) | 귀하의 알고리즘 거래 요구 사항에 맞는 완전한 REST, websocket 및 FTX API | `apiKey` | Yes | Yes |
+| [Gateio](https://www.gate.io/api2) | 블록체인 자산 거래소 | `apiKey` | Yes | Unknown |
+| [Gemini](https://docs.gemini.com/rest-api/) | 암호화폐 거래소 | No | Yes | Unknown |
+| [Hirak Exchange Rates](https://rates.hirak.site/) | 162개 통화와 300개 암호화폐 간의 환율은 5분마다 업데이트되며 정확하며 제한이 없습니다. | `apiKey` | Yes | Unknown |
+| [Huobi](https://huobiapi.github.io/docs/spot/v1/en/) | 세이셸 기반 암호화폐 거래소 | `apiKey` | Yes | Unknown |
+| [icy.tools](https://developers.icy.tools/) | GraphQL 기반 NFT API | `apiKey` | Yes | Unknown |
+| [Indodax](https://github.com/btcid/indodax-official-api-docs) | 비트코인 및 기타 자산을 루피아로 거래하세요 | `apiKey` | Yes | Unknown |
+| [INFURA Ethereum](https://infura.io/product/ethereum) | 이더리움 메인넷 및 여러 테스트넷과의 상호 작용 | `apiKey` | Yes | Yes |
+| [Kraken](https://docs.kraken.com/rest/) | 암호화폐 거래소 | `apiKey` | Yes | Unknown |
+| [KuCoin](https://docs.kucoin.com/) | 암호화폐 거래 플랫폼 | `apiKey` | Yes | Unknown |
+| [Localbitcoins](https://localbitcoins.com/api-docs/) | 비트코인을 사고 파는 P2P 플랫폼 | No | Yes | Unknown |
+| [Mempool](https://mempool.space/api) | 거래 수수료에 초점을 맞춘 비트코인 ​​API 서비스 | No | Yes | No |
+| [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | 브라질 암호화폐 정보 | No | Yes | Unknown |
+| [Messari](https://messari.io/api) | 수천 개의 암호화폐 자산에 대한 API 엔드포인트 제공 | No | Yes | Unknown |
+| [Nexchange](https://nexchange2.docs.apiary.io/) | 자동화된 암호화폐 거래소 서비스 | No | No | Yes |
+| [Nomics](https://nomics.com/docs/) | 과거 및 실시간 암호화폐 가격 및 시장 데이터 | `apiKey` | Yes | Yes |
+| [NovaDax](https://doc.novadax.com/en-US/#introduction) | 모든 시장 데이터, 거래 관리 엔드포인트에 액세스하는 NovaDAX API | `apiKey` | Yes | Unknown |
+| [OKEx](https://www.okex.com/docs/) | 세이셸에 본사를 둔 암호화폐 거래소 | `apiKey` | Yes | Unknown |
+| [Poloniex](https://docs.poloniex.com) | 미국 기반 디지털 자산 거래소 | `apiKey` | Yes | Unknown |
+| [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | 솔라나 블록체인과 상호작용할 수 있는 다양한 엔드포인트 제공 | No | Yes | Unknown |
+| [Technical Analysis](https://technical-analysis-api.com) | 암호화폐 가격 및 기술적 분석 | `apiKey` | Yes | No |
+| [VALR](https://docs.valr.com/) | 남아프리카공화국에 본사를 둔 암호화폐 거래소 | `apiKey` | Yes | Unknown |
+| [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | 암호화폐 가격 | `apiKey` | Yes | Unknown |
+| [ZMOK](https://zmok.io) | Ethereum JSON RPC API 및 Web3 공급자 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 환율
 
-|                                                     API                                                      | 설명                                               |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------------------------------------------------------------------: | -------------------------------------------------- | :------: | :---: | :-----: |
-|                        [1Forge](https://1forge.com/forex-data-api/api-documentation)                         | 외환 시장 데이터                                   | `apiKey` |  Yes  | Unknown |
-|                           [Currencylayer](https://currencylayer.com/documentation)                           | 환율 및 통화 변환                                  | `apiKey` |  Yes  | Unknown |
-| [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | 환율 모음                                          |    No    |  Yes  | Unknown |
-|                             [ExchangeRate-API](https://www.exchangerate-api.com)                             | 무료 통화 변환                                     | `apiKey` |  Yes  |   Yes   |
-|                              [Exchangeratesapi.io](https://exchangeratesapi.io)                              | 통화 변환이 포함된 환율                            | `apiKey` |  Yes  |   Yes   |
-|                                         [Fixer.io](http://fixer.io)                                          | 환율 및 통화 변환                                  | `apiKey` |  Yes  | Unknown |
-|                               [Frankfurter](https://www.frankfurter.app/docs)                                | 환율, 통화 변환 및 시계열                          |    No    |  Yes  |   Yes   |
-|                                    [FxRatesAPI](https://fxratesapi.com/)                                     | 실시간 환율, 과거 환율 및 통화 변환                | `apiKey` |  Yes  |   No    |
-|                                       [ratesapi](https://ratesapi.io)                                        | 무료 환율 및 과거 환율                             |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Currencylayer](https://currencylayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 환율 및 통화 변환 | `apiKey` | Yes | Unknown |
+| [Exchangerate.host](https://exchangerate.host?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 무료 외환 및 암호화폐 환율 API | No | Yes | Unknown |
+| [Exchangeratesapi.io](https://exchangeratesapi.io?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 통화 변환을 통한 환율 | `apiKey` | Yes | Yes |
+| [Fixer](https://fixer.io?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 환율 및 통화 변환 | `apiKey` | No | Unknown |
+| [1Forge](https://1forge.com/forex-data-api/api-documentation) | 외환 시장 데이터 | `apiKey` | Yes | Unknown |
+| [Amdoren](https://www.amdoren.com/currency-api/) | 150개 이상의 통화를 지원하는 무료 통화 API | `apiKey` | Yes | Unknown |
+| [Bank of Russia](https://www.cbr.ru/development/SXML/) | 환율 및 통화 변환 | No | Yes | Unknown |
+| [Currency-api](https://github.com/fawazahmed0/currency-api#readme) | 150개 이상의 통화를 지원하고 환율 제한이 없는 무료 환율 API | No | Yes | Yes |
+| [CurrencyFreaks](https://currencyfreaks.com/) | 월별 1,000건의 무료 플랜 요청으로 현재 및 과거 환율을 제공합니다. | `apiKey` | Yes | Yes |
+| [CurrencyScoop](https://currencyscoop.com/api-documentation) | 실시간 및 과거 환율 JSON API | `apiKey` | Yes | Yes |
+| [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | 환율 모음 | No | Yes | Unknown |
+| [Economia.Awesome](https://docs.awesomeapi.com.br/api-de-moedas) | 포르투갈어 무료 통화 가격 및 환율 제한 없는 변환 | No | Yes | Unknown |
+| [ExchangeRate-API](https://www.exchangerate-api.com) | 무료 통화 변환 | `apiKey` | Yes | Yes |
+| [Frankfurter](https://www.frankfurter.app/docs) | 환율, 통화 변환 및 시계열 | No | Yes | Yes |
+| [FreeForexAPI](https://freeforexapi.com/Home/Api) | 주요 통화쌍의 실시간 환율 | No | Yes | No |
+| [National Bank of Poland](http://api.nbp.pl/en.html) | 환율 모음(XML 및 JSON 데이터) | No | Yes | Yes |
+| [paralelo.bo](https://paralelo.bo/api) | 볼리비아 병행 시장 USD/BOB 환율은 60초마다 P2P 소스에서 집계됩니다. | No | Yes | Yes |
+| [VATComply.com](https://www.vatcomply.com/documentation) | 환율, 지리적 위치 및 VAT 번호 확인 | No | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 데이터 검증
 
-|                                     API                                     | 설명                                                        |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------------------------------: | ----------------------------------------------------------- | :------: | :---: | :-----: |
-|       [Cloudmersive Validate](https://cloudmersive.com/validate-api)        | 이메일 주소, 전화번호, VAT 번호 및 도메인 이름 검증         | `apiKey` |  Yes  |   Yes   |
-|                 [languagelayer](https://languagelayer.com)                  | 언어 감지                                                   |    No    |  Yes  | Unknown |
-|                         [Lob.com](https://lob.com/)                         | 미국 주소 검증                                              | `apiKey` |  Yes  | Unknown |
-|                  [mailboxlayer](https://mailboxlayer.com)                   | 이메일 주소 검증                                            |    No    |  Yes  | Unknown |
-|                   [NumValidate](https://numvalidate.com)                    | 오픈 소스 전화번호 검증                                     |    No    |  Yes  | Unknown |
-|                     [numverify](https://numverify.com)                      | 전화번호 검증                                               |    No    |  Yes  | Unknown |
-|       [Phone Validation](https://trestleiq.com/phone-validation-api/)       | 전화번호 검증 및 전화 메타데이터 제공                       | `apiKey` |  Yes  |   Yes   |
-|                   [PurgoMalum](http://www.purgomalum.com)                   | 욕설 및 외설적 콘텐츠 검증                                  |    No    |  No   | Unknown |
-| [US Autocomplete](https://smartystreets.com/docs/cloud/us-autocomplete-api) | 실시간 주소 제안으로 주소 데이터를 빠르게 입력              | `apiKey` |  Yes  |   Yes   |
-|    [US Extract](https://smartystreets.com/products/apis/us-extract-api)     | 이메일을 포함한 모든 텍스트에서 우편 주소 추출              | `apiKey` |  Yes  |   Yes   |
-|   [US Street Address](https://smartystreets.com/docs/cloud/us-street-api)   | 모든 미국 우편 주소를 검증하고 데이터 추가                  | `apiKey` |  Yes  |   Yes   |
-|                      [vatlayer](https://vatlayer.com)                       | VAT 번호 검증                                               |    No    |  Yes  | Unknown |
-|                      [Veriphone](https://veriphone.io)                      | 전화번호 검증 및 통신사 조회                                | `apiKey` |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [VATlayer](https://vatlayer.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | VAT 번호 확인 | `apiKey` | Yes | Unknown |
+| [Lob.com](https://lob.com/) | 미국 주소 검증 | `apiKey` | Yes | Unknown |
+| [Postman Echo](https://www.postman-echo.com) | HTTP 메소드로부터 값을 수신하고 반환하는 API 서버 테스트 | No | Yes | Unknown |
+| [PurgoMalum](http://www.purgomalum.com) | 욕설 및 외설적 콘텐츠 검증 | No | No | Unknown |
+| [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | 실시간 주소 제안으로 주소 데이터를 빠르게 입력하세요. | `apiKey` | Yes | Yes |
+| [US Extract](https://www.smarty.com/products/apis/us-extract-api) | 이메일을 포함한 모든 텍스트에서 우편 주소 추출 | `apiKey` | Yes | Yes |
+| [US Street Address](https://www.smarty.com/docs/cloud/us-street-api) | 모든 미국 우편 주소에 대한 데이터 유효성 검사 및 추가 | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 개발
 
-|                                                 API                                                 | 설명                                                                                    |      인증       | HTTPS |  CORS   |
-| :-------------------------------------------------------------------------------------------------: | --------------------------------------------------------------------------------------- | :-------------: | :---: | :-----: |
-|                         [24 Pull Requests](https://24pullrequests.com/api)                          | 12월 동안 오픈 소스 협업을 촉진하는 프로젝트                                            |       No        |  Yes  |   No    |
-|                              [Abacus](https://abacus.jasoncameron.dev)                              | 무료이고 간단한 카운팅 서비스. 페이지 조회수 및 특정 이벤트 추적                        |       No        |  Yes  |   Yes   |
-|                                   [addr.zone](https://addr.zone)                                    | IP 분류 및 인텔리전스 API. 프록시, 데이터센터, 악성 IP 탐지 등                         |       No        |  Yes  |   Yes   |
-|                                    [Agify.io](https://agify.io)                                     | 이름으로부터 나이 추정                                                                  |       No        |  Yes  |   Yes   |
-|                                  [ApiFlash](https://apiflash.com/)                                  | 개발자를 위한 Chrome 기반 스크린샷 API                                                  |    `apiKey`     |  Yes  | Unknown |
-|                               [APIs.guru](https://apis.guru/api-doc/)                               | 웹 API를 위한 위키피디아, 공개 API용 OpenAPI/Swagger 사양                               |       No        |  Yes  | Unknown |
-|                                 [BetterMeta](http://bettermeta.io)                                  | 사이트의 메타 태그를 JSON 형식으로 반환                                                 | `X-Mashape-Key` |  Yes  | Unknown |
-|                         [Browshot](https://browshot.com/api/documentation)                          | 모든 화면 크기, 모든 기기에서 웹 페이지 스크린샷 생성                                   |    `apiKey`     |  Yes  | Unknown |
-|                              [BrowserCat](https://www.browsercat.com/)                              | 자동화, 스크래핑 등을 위한 헤드리스 브라우저 API                                        |    `apiKey`     |  Yes  |   Yes   |
-|                           [CDNJS](https://api.cdnjs.com/libraries/jquery)                           | CDNJS의 라이브러리 정보                                                                 |       No        |  Yes  | Unknown |
-|                                   [Corsfix](https://corsfix.com)                                    | Corsfix의 CORS 프록시로 웹 리소스를 즉시 가져오고 CORS 오류 우회                       |       No        |  Yes  |   Yes   |
-|                    [DigitalOcean Status](https://status.digitalocean.com/api/v2)                    | 모든 DigitalOcean 서비스 상태                                                           |       No        |  Yes  | Unknown |
-|                               [Doczillla](https://www.doczilla.app/)                                | HTML/CSS/JS 코드에서 직접 스크린샷 또는 PDF 생성을 지원하는 SaaS API                   |    `apiKey`     |  Yes  | Unknown |
-|                     [ExtendsClass](https://extendsclass.com/json-storage.html)                      | 간단한 JSON 저장 API                                                                   |       No        |  Yes  |   Yes   |
-|                            [Faceplusplus](https://www.faceplusplus.com/)                            | 얼굴 감지 도구                                                                          |     `OAuth`     |  Yes  | Unknown |
-|                          [FontDownloader](https://fontdownloader.org/#API)                          | Google Fonts에서 제공하는 웹 폰트 관리를 위한 번거로움 없는 API                         |       No        |  Yes  |   Yes   |
-|                              [Form2Channel](https://form2channel.com/)                              | 정적 HTML 양식 제출을 Google Sheets, 이메일, Slack 또는 Telegram으로 전송              |       No        |  Yes  |   Yes   |
-|                                [Genderize.io](https://genderize.io)                                 | 이름으로부터 성별 추정                                                                  |       No        |  Yes  |   Yes   |
-|                             [GitHub](https://developer.github.com/v3/)                              | GitHub 저장소, 코드 및 사용자 정보를 프로그래밍 방식으로 사용                           |     `OAuth`     |  Yes  |   Yes   |
-|                              [Gitlab](https://docs.gitlab.com/ee/api/)                              | GitLab 상호작용을 프로그래밍 방식으로 자동화                                            |     `OAuth`     |  Yes  | Unknown |
-|                             [Gitter](https://github.com/gitterHQ/docs)                              | GitHub용 채팅                                                                          |     `OAuth`     |  Yes  | Unknown |
-|                               [HTTP2.Pro](https://http2.pro/doc/api)                                | 클라이언트 및 서버 HTTP/2 프로토콜 지원을 위한 테스트 엔드포인트                       |       No        |  Yes  | Unknown |
-| [IBM Text to Speech](https://console.bluemix.net/docs/services/text-to-speech/getting-started.html) | 텍스트를 음성으로 변환                                                                  |    `apiKey`     |  Yes  |   Yes   |
-|                            [Image-Charts](https://www.image-charts.com/)                            | 차트, QR 코드 및 그래프 이미지 생성                                                     |       No        |  Yes  |   Yes   |
-|                               [import.io](http://api.docs.import.io/)                               | 웹사이트 또는 RSS 피드에서 구조화된 데이터 검색                                         |    `apiKey`     |  Yes  | Unknown |
-|                       [IP2WHOIS Information Lookup](https://www.ip2whois.com)                       | WHOIS 도메인 이름 조회                                                                  |    `apiKey`     |  Yes  | Unknown |
-|                      [IP2WHOIS Hosted Domain Lookup](https://www.ip2whois.com)                      | 호스팅된 도메인 조회                                                                    |    `apiKey`     |  Yes  | Unknown |
-|                            [ipapi.is](https://ipapi.is/developers.html)                             | 회사, ASN 및 호스팅 감지 지원을 포함한 공개 IP 주소 API                                 |       No        |  Yes  |   Yes   |
-|                    [IPGEO](https://api.techniknews.net/ipgeo/[IP-Adress/Domain])                    | 유용한 정보가 포함된 무제한 무료 IP 주소 API                                           |       No        |  Yes  | Unknown |
-|                                   [IPify](https://www.ipify.org/)                                   | 간단한 IP 주소 API                                                                     |       No        |  Yes  | Unknown |
-|                               [IPinfo](https://ipinfo.io/developers)                                | 또 다른 간단한 IP 주소 API                                                             |       No        |  Yes  | Unknown |
-|                             [IPLocate.io](https://www.iplocate.io/docs)                             | 빠르고 무료이며 정확한 IP 지리위치 및 위협 데이터 (프록시/VPN/호스팅 감지) API          |       No        |  Yes  |   Yes   |
-|                          [ArulJohn.com](https://api.aruljohn.com/ip/json)                           | JSON 형식의 간단한 IP 주소 API                                                          |       No        |  Yes  |   Yes   |
-|                      [jsDelivr](https://github.com/jsdelivr/data.jsdelivr.com)                      | jsDelivr CDN의 패키지 정보 및 다운로드 통계                                             |       No        |  Yes  |   Yes   |
-|                               [JSON 2 JSONP](https://json2jsonp.com/)                               | 클라이언트 측 JavaScript를 사용한 간편한 크로스 도메인 데이터 요청을 위해 JSON을 JSONP로 변환 (즉석) |       No        |  Yes  | Unknown |
-|                                  [JSONbin.io](https://jsonbin.io)                                   | 무료 JSON 스토리지 서비스. 소규모 웹 앱, 웹사이트, 모바일 앱에 이상적                  |    `apiKey`     |  Yes  |   Yes   |
-|                                  [Judge0](https://api.judge0.com/)                                  | 소스 코드 컴파일 및 실행                                                                |       No        |  Yes  | Unknown |
-|                        [Let's Validate](https://github.com/letsvalidate/api)                        | 웹사이트에 사용된 기술 발견 및 URL을 썸네일로 변환                                      |       No        |  Yes  | Unknown |
-|           [License-API](https://github.com/cmccandless/license-api/blob/master/README.md)           | choosealicense.com을 위한 비공식 REST API                                               |       No        |  Yes  |   No    |
-|                         [MAC address vendor lookup](https://macaddress.io)                          | 주어진 MAC 주소 또는 OUI에 대한 공급업체 세부 정보 및 기타 정보 검색                   |    `apiKey`     |  Yes  |   Yes   |
-|                               [MyJSON.online](https://myjson.online)                                | JSON 데이터의 유연한 저장을 위한 RESTful API                                            |    `apiKey`     |  Yes  |   Yes   |
-|                              [Nationalize.io](https://nationalize.io)                               | 이름의 국적 추정                                                                        |       No        |  Yes  |   Yes   |
-|                                   [OOPSpam](https://oopspam.com/)                                   | 다중 스팸 필터링 서비스                                                                 |       No        |  Yes  |   Yes   |
-|                             [Postman](https://docs.api.getpostman.com/)                             | API 테스트 도구                                                                         |    `apiKey`     |  Yes  | Unknown |
-|                                [ProxyCrawl](https://proxycrawl.com)                                 | 스크래핑 및 크롤링 안티캡차 서비스                                                      |    `apiKey`     |  Yes  | Unknown |
-|                      [Public APIs](https://github.com/davemachado/public-api)                       | 웹 개발에 사용하기 위한 무료 JSON API들의 종합 목록                                     |       No        |  Yes  | Unknown |
-|                              [Pusher Beams](https://pusher.com/beams)                               | Android 및 iOS용 푸시 알림                                                              |    `apiKey`     |  Yes  | Unknown |
-|                              [Pythonium](https://pythonium.net/linter)                              | Python 코드 검증                                                                       |       No        |  Yes  |   Yes   |
-|                          [QR Code](https://fungenerators.com/api/qrcode/)                           | 새 QR 코드 생성 또는 기존 QR 코드 디코딩                                                |    `apiKey`     |  Yes  |   Yes   |
-|                                  [QR code](http://qrtag.net/api/)                                   | 읽기 쉬운 QR 코드 및 URL 단축기 생성                                                    |       No        |  Yes  |   Yes   |
-|                                   [QR code](http://goqr.me/api/)                                    | QR 코드 그래픽 생성 및 디코딩/읽기                                                      |       No        |  Yes  | Unknown |
-|                                [QuickChart](https://quickchart.io/)                                 | 차트 및 그래프 이미지 생성                                                              |       No        |  Yes  |   Yes   |
-|                                    [ReqRes](https://reqres.in/)                                     | AJAX 요청에 응답할 준비가 된 호스팅된 REST-API                                          |       No        |  Yes  | Unknown |
-|                              [ScraperApi](https://www.scraperapi.com)                               | 확장 가능한 웹 스크래퍼를 쉽게 구축                                                     |    `apiKey`     |  Yes  | Unknown |
-|                           [ScreenshotAPI.net](https://screenshotapi.net/)                           | 픽셀 완벽한 웹사이트 스크린샷 생성                                                      |    `apiKey`     |  Yes  |   Yes   |
-|                          [Shadify](https://github.com/cheatsnake/shadify)                           | 다양한 게임 및 퍼즐 생성을 위한 데이터 생성 및 로직 실행 서비스                         |       No        |  Yes  |   Yes   |
-|                                 [SHOUTCLOUD](http://shoutcloud.io/)                                 | 서비스로서의 모든 대문자                                                                |       No        |  No   | Unknown |
-|                           [StackExchange](https://api.stackexchange.com/)                           | 개발자를 위한 Q&A 포럼                                                                  |     `OAuth`     |  Yes  | Unknown |
-|                         [XML to JSON](https://developers.wso2apistore.com/)                         | 통합 개발자 유틸리티 API                                                                |       No        |  Yes  | Unknown |
-|         [Image to Link](https://www.contentful.com/developers/docs/references/images-api/)          | 이미지에서 링크 생성 (통합 개발자 유틸리티 API)                                         |       No        |  Yes  |   Yes   |
-|                                  [IPFinder](https://ipfinder.io/)                                   | 지리위치 API, ASN API, IP 범위 API, IP 방화벽 API, 도메인 API                          |    `apiKey`     |  Yes  |   Yes   |
-|                                 [Scraper.run](https://scraper.run/)                                 | 지리위치 API, 도메인의 DNS 및 whois 레코드 조회                                        |       No        |  Yes  |   Yes   |
-|                                   [SerpApi](https://serpapi.com/)                                   | 간단한 API로 Google 및 기타 검색 엔진 스크래핑                                          |    `apiKey`     |  Yes  |   No    |
-|                         [v.recipes DNS Accelerator](https://v.recipes/dns/)                         | 모든 DoH 제공업체를 테스트하고 가속화하는 데 사용할 수 있는 가속기 변형                |       No        |  Yes  |   No    |
-|                            [v.recipes Get IP](https://v.recipes/get-ip)                             | 사용자 요청에 따라 IP, ISP 이름, 위치 등의 정보를 얻는 간단한 API                      |       No        |  Yes  |   No    |
-|                             [WebCrawlerAPI](https://webcrawlerapi.com/)                             | 웹사이트에서 콘텐츠를 쉽게 추출                                                         |    `apiKey`     |  Yes  |   Yes   |
-|                                     [Zuplo](https://zuplo.com/)                                     | 개발, 배포, 문서화를 위한 API 플랫폼 - 인증, 속도 제한, 수익화를 빠르게 추가           |    `apiKey`     |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Userstack](https://userstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 보안 사용자 에이전트 문자열 조회 JSON API | `OAuth` | Yes | Unknown |
+| [24 Pull Requests](https://24pullrequests.com/api) | 12월 동안 오픈 소스 협업을 촉진하는 프로젝트 | No | Yes | Yes |
+| [Agify.io](https://agify.io) | 이름으로부터 나이 추정 | No | Yes | Yes |
+| [API Grátis](https://apigratis.com.br/) | 다중 서비스 및 공개 API | No | Yes | Unknown |
+| [ApicAgent](https://www.apicagent.com) | 사용자 에이전트 문자열에서 장치 세부정보 추출 | No | Yes | Yes |
+| [ApiFlash](https://apiflash.com/) | 개발자를 위한 Chrome 기반 스크린샷 API | `apiKey` | Yes | Unknown |
+| [APIs.guru](https://apis.guru/api-doc/) | 웹 API를 위한 위키피디아, 공개 API용 OpenAPI/Swagger 사양 | No | Yes | Unknown |
+| [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | REST API 요청/응답 쌍의 Azure DevOps 기본 구성 요소 | `apiKey` | Yes | Unknown |
+| [Base](https://www.base-api.io/) | 빠른 백엔드 구축 | `apiKey` | Yes | Yes |
+| [Beeceptor](https://beeceptor.com/) | 몇 초 만에 모의 Rest API 엔드포인트 구축 | No | Yes | Yes |
+| [Bitbucket](https://developer.atlassian.com/bitbucket/api/2/reference/) | 비트버킷 API | `OAuth` | Yes | Unknown |
+| [Blague.xyz](https://blague.xyz/) | La plus grande API de Blagues FR/가장 큰 FR 농담 API | `apiKey` | Yes | Yes |
+| [Blitapp](https://blitapp.com/api/) | 웹페이지의 스크린샷을 예약하고 클라우드에 동기화하세요. | `apiKey` | Yes | Unknown |
+| [Blynk-Cloud](https://blynkapi.docs.apiary.io/#) | Blynk IoT Cloud에서 IoT 장치 제어 | `apiKey` | No | Unknown |
+| [Bored](https://www.boredapi.com/) | 지루함을 달래기 위한 무작위 활동 찾기 | No | Yes | Unknown |
+| [Brainshop.ai](https://brainshop.ai/) | 무료 AI 두뇌 만들기 | `apiKey` | Yes | Yes |
+| [BrewPage](https://brewpage.app) | HTML, JSON, 키-값, 파일, 짧은 URL 및 TTL 보존 기능이 있는 다중 파일 사이트를 위한 무료 호스팅 | No | Yes | No |
+| [Browshot](https://browshot.com/api/documentation) | 모든 화면 크기, 모든 기기에서 웹 페이지 스크린샷 생성 | `apiKey` | Yes | Yes |
+| [CDNJS](https://api.cdnjs.com/libraries/jquery) | CDNJS의 라이브러리 정보 | No | Yes | Unknown |
+| [Changelogs.md](https://changelogs.md) | 오픈 소스 프로젝트의 구조화된 변경 로그 메타데이터 | No | Yes | Unknown |
+| [Ciprand](https://github.com/polarspetroll/ciprand) | 안전한 무작위 문자열 생성기 | No | Yes | No |
+| [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | IP 주소, 타임스탬프, 사용자 에이전트, 국가 코드, IATA, HTTP 버전, TLS/SSL 버전 등을 가져옵니다. | No | Yes | Yes |
+| [Codex](https://github.com/Jaagrav/CodeX) | 다양한 언어를 위한 온라인 컴파일러 | No | Yes | Unknown |
+| [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/) | 이미지에서 링크 생성 (통합 개발자 유틸리티 API) | `apiKey` | Yes | Yes |
+| [CORS Proxy](https://github.com/burhanuday/cors-proxy) | 이 프록시를 중개자로 사용하여 두려운 CORS 오류를 해결하세요. | No | Yes | Yes |
+| [CountAPI](https://countapi.xyz) | 무료로 간편하게 계수 서비스를 제공합니다. 이를 사용하여 페이지 조회수 및 특정 이벤트를 추적할 수 있습니다. | No | Yes | Yes |
+| [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html) | Databricks 계정, 클러스터, 노트북, 작업 및 작업 공간을 관리하는 서비스 | `apiKey` | Yes | Yes |
+| [DigitalOcean Status](https://status.digitalocean.com/api) | 모든 DigitalOcean 서비스 상태 | No | Yes | Unknown |
+| [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Docker Hub와 상호작용 | `apiKey` | Yes | Yes |
+| [DomainDb Info](https://api.domainsdb.info/) | 특정 단어/문구/등을 포함하는 모든 도메인을 찾기 위한 도메인 이름 검색 | No | Yes | Unknown |
+| [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | 간단한 JSON 저장 API | No | Yes | Yes |
+| [GeekFlare](https://apidocs.geekflare.com/docs/geekflare-api) | 웹사이트에 대한 중요한 테스트 및 모니터링 방법을 위한 다양한 기능 제공 | `apiKey` | Yes | Unknown |
+| [Genderize.io](https://genderize.io) | 이름으로부터 성별 추정 | No | Yes | Yes |
+| [GETPing](https://www.getping.info) | 간단한 GET 요청으로 이메일 알림 트리거 | `apiKey` | Yes | Unknown |
+| [Ghost](https://ghost.org/) | 웹사이트, 앱 또는 기타 내장 미디어에 게시된 콘텐츠를 가져옵니다. | `apiKey` | Yes | Yes |
+| [GitHub](https://docs.github.com/en/free-pro-team@latest/rest) | GitHub 리포지토리, 코드 및 사용자 정보를 프로그래밍 방식으로 활용 | `OAuth` | Yes | Yes |
+| [Gitlab](https://docs.gitlab.com/ee/api/) | GitLab 상호작용을 프로그래밍 방식으로 자동화 | `OAuth` | Yes | Unknown |
+| [Gitter](https://developer.gitter.im/docs/welcome) | 개발자를 위한 채팅 | `OAuth` | Yes | Unknown |
+| [Glitterly](https://developers.glitterly.app) | 이미지 생성 API | `apiKey` | Yes | Yes |
+| [Google Docs](https://developers.google.com/docs/api/reference/rest) | Google Docs 문서를 읽고, 쓰고, 서식을 지정하는 API | `OAuth` | Yes | Unknown |
+| [Google Firebase](https://firebase.google.com/docs) | 앱을 구축, 개선, 성장시키는 데 도움이 되는 Google의 모바일 애플리케이션 개발 플랫폼 | `apiKey` | Yes | Yes |
+| [Google Fonts](https://developers.google.com/fonts/docs/developer_api) | Google Fonts에서 제공하는 모든 계열에 대한 메타데이터 | `apiKey` | Yes | Unknown |
+| [Google Keep](https://developers.google.com/keep/api/reference/rest) | Google Keep 메모를 읽고, 쓰고, 형식을 지정하는 API | `OAuth` | Yes | Unknown |
+| [Google Sheets](https://developers.google.com/sheets/api/reference/rest) | Google Sheets 데이터를 읽고, 쓰고, 형식을 지정하는 API | `OAuth` | Yes | Unknown |
+| [Google Slides](https://developers.google.com/slides/api/reference/rest) | Google Slides 프레젠테이션을 읽고, 쓰고, 형식을 지정하는 API | `OAuth` | Yes | Unknown |
+| [Gorest](https://gorest.co.in/) | 테스트 및 프로토타입 제작을 위한 온라인 REST API | `OAuth` | Yes | Unknown |
+| [Hasura](https://hasura.io/opensource/) | 권한 부여 기능이 내장된 GraphQL 및 REST API 엔진 | `apiKey` | Yes | Yes |
+| [Heroku](https://devcenter.heroku.com/articles/platform-api-reference/) | 프로그래밍 방식으로 앱을 생성하고, 추가 기능을 제공하고, Heroku에서 기타 작업을 수행하는 REST API | `OAuth` | Yes | Yes |
+| [host-t.com](https://host-t.com) | HTTP GET 요청을 통한 기본 DNS 쿼리 | No | Yes | No |
+| [Host.io](https://host.io) | 개발자를 위한 도메인 데이터 API | `apiKey` | Yes | Yes |
+| [HTTP2.Pro](https://http2.pro/doc/api) | 클라이언트 및 서버 HTTP/2 프로토콜 지원을 위한 테스트 엔드포인트 | No | Yes | Unknown |
+| [Httpbin](https://httpbin.org/) | 간단한 HTTP 요청 및 응답 서비스 | No | Yes | Yes |
+| [Httpbin Cloudflare](https://cloudflare-quic.com/b/) | Cloudflare의 HTTP/3 지원을 갖춘 간단한 HTTP 요청 및 응답 서비스 | No | Yes | Yes |
+| [Hunter](https://hunter.io/api) | 도메인 검색, 전문 이메일 찾기, 작성자 찾기 및 이메일 검증을 위한 API | `apiKey` | Yes | Unknown |
+| [IBM Text to Speech](https://cloud.ibm.com/docs/text-to-speech/getting-started.html) | 텍스트를 음성으로 변환 | `apiKey` | Yes | Yes |
+| [Icanhazepoch](https://icanhazepoch.com) | 에포크 시간 가져오기 | No | Yes | Yes |
+| [Icanhazip](https://major.io/icanhazip-com-faq/) | IP 주소 API | No | Yes | Yes |
+| [IFTTT](https://platform.ifttt.com/docs/connect_api) | IFTTT 연결 API | No | Yes | Unknown |
+| [Image-Charts](https://documentation.image-charts.com/) | 차트, QR 코드 및 그래프 이미지 생성 | No | Yes | Yes |
+| [import.io](http://api.docs.import.io/) | 웹사이트 또는 RSS 피드에서 구조화된 데이터 검색 | `apiKey` | Yes | Unknown |
+| [ip-fast.com](https://ip-fast.com/docs/) | IP 주소, 국가 및 도시 | No | Yes | Yes |
+| [IP2WHOIS Information Lookup](https://www.ip2whois.com/) | WHOIS 도메인 이름 조회 | `apiKey` | Yes | Unknown |
+| [ipfind.io](https://ipfind.io) | 기타 유용한 정보와 함께 IP 주소 또는 도메인 이름의 지리적 위치 | `apiKey` | Yes | Yes |
+| [IPify](https://www.ipify.org/) | 간단한 IP 주소 API | No | Yes | Unknown |
+| [IPinfo](https://ipinfo.io/developers) | 또 다른 간단한 IP 주소 API | No | Yes | Unknown |
+| [isitdownstatus](https://isitdownstatus.com) | 현재 웹사이트와 온라인 서비스가 다운되었는지 확인하세요. | No | Yes | Unknown |
+| [jsDelivr](https://github.com/jsdelivr/data.jsdelivr.com) | jsDelivr CDN의 패키지 정보 및 다운로드 통계 | No | Yes | Yes |
+| [JSON 2 JSONP](https://json2jsonp.com/) | 클라이언트 측 JavaScript를 사용한 간편한 크로스 도메인 데이터 요청을 위해 JSON을 JSONP로 변환 (즉석) | No | Yes | Unknown |
+| [JSONbin.io](https://jsonbin.io) | 무료 JSON 스토리지 서비스. 소규모 웹 앱, 웹사이트, 모바일 앱에 이상적 | `apiKey` | Yes | Yes |
+| [JSONPlaceholder](https://jsonplaceholder.typicode.com) | 테스트 및 프로토타이핑을 위한 가짜 REST API | No | Yes | Yes |
+| [Kroki](https://kroki.io) | 텍스트 설명으로 다이어그램을 만듭니다. | No | Yes | Yes |
+| [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | choosealicense.com을 위한 비공식 REST API | No | Yes | No |
+| [Logs.to](https://logs.to/) | 로그 생성 | `apiKey` | Yes | Unknown |
+| [Lua Decompiler](https://lua-decompiler.ferib.dev/) | 온라인 Lua 5.1 디컴파일러 | No | Yes | Yes |
+| [MAC address vendor lookup](https://macaddress.io/api) | 특정 MAC 주소 또는 OUI에 관한 공급업체 세부 정보 및 기타 정보를 검색합니다. | `apiKey` | Yes | Yes |
+| [Micro DB](https://m3o.com/db) | 간단한 데이터베이스 서비스 | `apiKey` | Yes | Unknown |
+| [MicroENV](https://microenv.com/) | 개발자를 위한 가짜 Rest API | No | Yes | Unknown |
+| [Mocky](https://designer.mocky.io/) | REST API 엔드포인트에 대한 모의 사용자 정의 테스트 JSON | No | Yes | Yes |
+| [MY IP](https://www.myip.com/api-docs/) | IP 주소 정보 얻기 | No | Yes | Unknown |
+| [Nationalize.io](https://nationalize.io) | 이름의 국적 추정 | No | Yes | Yes |
+| [Netlify](https://docs.netlify.com/api/get-started/) | Netlify는 프로그래밍 가능한 웹을 위한 호스팅 서비스입니다. | `OAuth` | Yes | Unknown |
+| [NetworkCalc](https://networkcalc.com/api/docs) | 서브넷, DNS, 바이너리 및 보안 도구를 포함한 네트워크 계산기 | No | Yes | Yes |
+| [npm Registry](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md) | 프로그래밍 방식으로 즐겨찾는 Node.js 라이브러리에 대한 정보 쿼리 | No | Yes | Unknown |
+| [OneSignal](https://documentation.onesignal.com/docs/onesignal-api) | 푸시 알림, 이메일, SMS 및 인앱을 위한 셀프 서비스 고객 참여 솔루션 | `apiKey` | Yes | Unknown |
+| [Open Page Rank](https://www.domcop.com/openpagerank/) | 페이지 순위 알고리즘을 사용하여 다양한 웹사이트의 지표를 계산하고 비교하는 API | `apiKey` | Yes | Unknown |
+| [OpenAPIHub](https://hub.openapihub.com/) | 올인원 API 플랫폼 | `X-Mashape-Key` | Yes | Unknown |
+| [OpenGraphr](https://opengraphr.com/docs/1.0/overview) | URL에서 오픈 그래프 데이터를 검색하는 매우 간단한 API | `apiKey` | Yes | Unknown |
+| [oyyi](https://oyyi.xyz/docs/1.0) | 가짜 데이터, 이미지/비디오 변환, 최적화, PDF 최적화 및 썸네일 생성을 위한 API | No | Yes | Yes |
+| [PageCDN](https://pagecdn.com/docs/public-api) | PageCDN의 자바스크립트, CSS 및 글꼴 라이브러리용 공개 API | `apiKey` | Yes | Yes |
+| [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | API 테스트 도구 | `apiKey` | Yes | Unknown |
+| [ProxyCrawl](https://proxycrawl.com) | 스크래핑 및 크롤링 안티캡차 서비스 | `apiKey` | Yes | Unknown |
+| [ProxyKingdom](https://proxykingdom.com) | 모든 요청에 ​​대해 작동하는 프록시를 생성하는 회전 프록시 API | `apiKey` | Yes | Yes |
+| [Pusher Beams](https://pusher.com/beams) | Android 및 iOS용 푸시 알림 | `apiKey` | Yes | Unknown |
+| [QR code](https://www.qrtag.net/api/) | 읽기 쉬운 QR 코드 및 URL 단축 도구 만들기 | No | Yes | Yes |
+| [QR code](http://goqr.me/api/) | QR 코드 그래픽 생성 및 디코딩/읽기 | No | Yes | Unknown |
+| [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | 사용자 지정 고유한 모양의 QR 코드를 시스템이나 작업 흐름에 통합하세요. | No | Yes | Unknown |
+| [QuickChart](https://quickchart.io/) | 차트 및 그래프 이미지 생성 | No | Yes | Yes |
+| [Random Stuff](https://api-docs.pgamerx.com/) | 번개처럼 빠른 속도로 AI 응답, 농담, 밈 등을 얻는 데 사용할 수 있습니다. | `apiKey` | Yes | Yes |
+| [Rejax](https://rejax.io/) | 클라이언트에게 알리는 역방향 AJAX 서비스 | `apiKey` | Yes | No |
+| [ReqRes](https://reqres.in/) | AJAX 요청에 응답할 준비가 된 호스팅된 REST-API | No | Yes | Unknown |
+| [RSS feed to JSON](https://rss-to-json-serverless-api.vercel.app) | 피드 URL을 사용하여 RSS 피드를 JSON 형식으로 반환합니다. | No | Yes | Yes |
+| [SavePage.io](https://www.savepage.io) | 데스크탑이나 모바일 웹사이트의 스크린샷을 찍는 데 사용되는 무료 RESTful API | `apiKey` | Yes | Yes |
+| [ScrapeNinja](https://scrapeninja.net) | Chrome 지문 및 주거용 프록시를 사용한 스크래핑 API | `apiKey` | Yes | Unknown |
+| [ScraperApi](https://www.scraperapi.com) | 확장 가능한 웹 스크래퍼를 쉽게 구축 | `apiKey` | Yes | Unknown |
+| [scraperBox](https://scraperbox.com/) | 감지할 수 없는 웹 스크래핑 API | `apiKey` | Yes | Yes |
+| [scrapestack](https://scrapestack.com/) | 실시간, 확장 가능한 프록시 및 웹 스크래핑 REST API | `apiKey` | Yes | Unknown |
+| [ScrapingAnt](https://scrapingant.com) | 간단한 API를 사용한 헤드리스 Chrome 스크래핑 | `apiKey` | Yes | Unknown |
+| [ScrapingDog](https://www.scrapingdog.com/) | 웹 스크래핑을 위한 프록시 API | `apiKey` | Yes | Unknown |
+| [Screenshot](https://www.abstractapi.com/website-screenshot-api) | 모든 웹사이트에서 웹페이지의 프로그래밍 방식 스크린샷을 찍습니다. | `apiKey` | Yes | Yes |
+| [ScreenshotAPI.net](https://screenshotapi.net/) | 픽셀 완벽한 웹사이트 스크린샷 생성 | `apiKey` | Yes | Yes |
+| [Serialif Color](https://color.serialif.com/) | 색상 변환, 보완, 회색조 및 대비 텍스트 | No | Yes | No |
+| [serpstack](https://serpstack.com/) | 실시간 및 정확한 Google 검색 결과 API | `apiKey` | Yes | Yes |
+| [Sheetsu](https://sheetsu.com/) | 간편한 Google 시트 통합 | `apiKey` | Yes | Unknown |
+| [SHOUTCLOUD](http://shoutcloud.io/) | 서비스로서의 모든 대문자 | No | No | Unknown |
+| [Sonar](https://github.com/Cgboal/SonarSearch) | 프로젝트 소나 DNS 열거 API | No | Yes | Yes |
+| [SonarQube](https://sonarcloud.io/web_api) | 버그, 코드 냄새 및 보안 취약점을 탐지하는 SonarQube REST API | `OAuth` | Yes | Unknown |
+| [StackExchange](https://api.stackexchange.com/) | 개발자를 위한 Q&A 포럼 | `OAuth` | Yes | Unknown |
+| [Statically](https://statically.io/) | 개발자를 위한 무료 CDN | No | Yes | Yes |
+| [Supportivekoala](https://developers.supportivekoala.com/) | 템플릿을 사용하여 이미지 자동 생성 | `apiKey` | Yes | Yes |
+| [Suprsonic](https://suprsonic.ai) | 통합 에이전트 API: 검색, 스크랩, 강화, 이미지 생성, TTS, STT, 메시징. 하나의 키, 20개 이상의 기능 | `apiKey` | Yes | Yes |
+| [Thunderbit](https://thunderbit.com/docs/introduction) | AI 앱을 위한 마크다운 또는 구조화된 데이터로 웹페이지 추출 | `apiKey` | Yes | Unknown |
+| [Tyk](https://tyk.io/open-source/) | API 및 서비스 관리 플랫폼 | `apiKey` | Yes | Yes |
+| [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel2/API.rst) | wandbox.org에 언급된 35개 이상의 언어를 지원하는 코드 컴파일러 | No | Yes | Unknown |
+| [WebScraping.AI](https://webscraping.ai/) | 프록시와 JS 렌더링이 내장된 웹 스크래핑 API | `apiKey` | Yes | Yes |
+| [ZenRows](https://www.zenrows.com/) | JS 렌더링 및 회전 프록시를 제공하면서 안티봇 솔루션을 우회하는 웹 스크래핑 API | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 사전
 
-|                         API                         | 설명                                           |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------: | ---------------------------------------------- | :------: | :---: | :-----: |
-|     [Lingua Robot](https://www.linguarobot.io)      | 단어 정의, 발음, 동의어, 반의어 등             | `apiKey` |  Yes  |   Yes   |
-|    [Merriam-Webster](https://dictionaryapi.com/)    | 사전 및 유의어 사전 데이터                     | `apiKey` |  Yes  | Unknown |
-| [Oxford](https://developer.oxforddictionaries.com/) | 사전 데이터                                    | `apiKey` |  Yes  |   No    |
-|       [Wordnik](http://developer.wordnik.com)       | 사전 데이터                                    | `apiKey` |  No   | Unknown |
-|         [Words](https://www.wordsapi.com/)          | 150,000개 이상 단어의 정의 및 동의어           | `apiKey` |  Yes  | Unknown |
-
-**[⬆ 목차로 돌아가기](#목차)**
-
-### 재해
-
-|                           API                           | 설명                    |   인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------: | ----------------------- | :------: | :---: | :-----: |
-|   [USGS](https://earthquake.usgs.gov/fdsnws/event/1/)   | 지진 데이터             | `apiKey` |  Yes  | Unknown |
-|      [RWLabs](https://apidoc.rwlabs.org/#api-use)       | 모든 유형의 재해 데이터 | `apiKey` |  Yes  | Unknown |
-|        [PredictHQ](https://docs.predicthq.com/)         | 이벤트 및 자연재해 데이터 |  oAuth   |  Yes  | Unknown |
-| [Ambee](https://www.getambee.com/api/natural-disasters) | 자연재해 API            | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Chinese Character Web](http://ccdb.hemiola.com/) | 한자의 정의와 발음 | No | No | No |
+| [Chinese Text Project](https://ctext.org/tools/api) | 전근대 중국어 텍스트를 위한 온라인 개방형 디지털 라이브러리 | No | Yes | Unknown |
+| [Collins](https://api.collinsdictionary.com/api/v1/documentation/html/) | 이중 언어 사전 및 동의어 사전 데이터 | `apiKey` | Yes | Unknown |
+| [Free Dictionary](https://dictionaryapi.dev/) | 정의, 음성학, 발음, 품사, 예, 동의어 | No | Yes | Unknown |
+| [Indonesia Dictionary](https://new-kbbi-api.herokuapp.com/) | 인도네시아 사전 많은 단어 | No | Yes | Unknown |
+| [Lingua Robot](https://www.linguarobot.io) | 단어 정의, 발음, 동의어, 반의어 등 | `apiKey` | Yes | Yes |
+| [Merriam-Webster](https://dictionaryapi.com/) | 사전 및 유의어 사전 데이터 | `apiKey` | Yes | Unknown |
+| [OwlBot](https://owlbot.info/) | 가능한 경우 예문과 사진이 포함된 정의 | `apiKey` | Yes | Yes |
+| [Oxford](https://developer.oxforddictionaries.com/) | 사전 데이터 | `apiKey` | Yes | No |
+| [Synonyms](https://www.synonyms.com/synonyms_api.php) | 특정 단어에 대한 동의어, 유의어 사전, 반의어 정보 | `apiKey` | Yes | Unknown |
+| [Wiktionary](https://en.wiktionary.org/w/api.php) | 협업 사전 데이터 | No | Yes | Yes |
+| [Wordnik](https://developer.wordnik.com) | 사전 데이터 | `apiKey` | Yes | Unknown |
+| [Words](https://www.wordsapi.com/docs/) | 150,000개 이상의 단어에 대한 정의 및 동의어 | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 문서 & 생산성
 
-|                                        API                                        | 설명                                                     |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------------------------------------: | -------------------------------------------------------- | :------: | :---: | :-----: |
-| [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL을 PDF/PNG로, Office 문서를 PDF로, 이미지 변환  | `apiKey` |  Yes  |   Yes   |
-|                       [DynamicDocs](https://advicement.io)                        | LaTeX 기반 JSON to PDF API로 동적 PDF 생성              | `apiKey` |  Yes  | Unknown |
-|                          [File.io](https://www.file.io)                           | 파일 공유                                                |    No    |  Yes  | Unknown |
-|                      [Mercury](https://reader.postlight.com)                      | 웹 파서                                                  | `apiKey` |  Yes  | Unknown |
-|                      [pdfEndpoint](https://pdfendpoint.com)                       | HTML 또는 URL을 PDF로                                    | `apiKey` |  Yes  |   No    |
-|                         [pdflayer](https://pdflayer.com)                          | HTML/URL을 PDF로                                         | `apiKey` |  Yes  | Unknown |
-|                    [Pocket](https://getpocket.com/developer/)                     | 북마크 서비스                                            | `OAuth`  |  Yes  | Unknown |
-|                         [PrexView](https://prexview.com)                          | XML 또는 JSON에서 PDF, HTML 또는 이미지로 데이터 변환    | `apiKey` |  Yes  | Unknown |
-|                       [RenderPDF.io](https://renderpdf.io/)                       | 가장 빠른 HTML to PDF, 월 500개 PDF 무료                | `apiKey` |  Yes  |   Yes   |
-|                         [Restpack](https://restpack.io/)                          | 스크린샷, HTML to PDF 및 콘텐츠 추출 API 제공           | `apiKey` |  Yes  | Unknown |
-|                     [Todoist](https://developer.todoist.com)                      | 할 일 목록                                               | `OAuth`  |  Yes  | Unknown |
-|                      [Vector Express](http://vector.express)                      | 무료 벡터 파일 변환 API                                  |    No    |  No   |   Yes   |
-|               [Vertopal](https://www.vertopal.com/en/developer/api)               | Vertopal API를 사용한 파일 변환                          | `apiKey` |  Yes  |   No    |
-|                    [WakaTime](https://wakatime.com/developers)                    | 프로그래머를 위한 자동화된 시간 추적 리더보드            |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Airtable](https://airtable.com/api) | Airtable과 통합 | `apiKey` | Yes | Unknown |
+| [Api2Convert](https://www.api2convert.com/) | 온라인 파일 변환 API | `apiKey` | Yes | Unknown |
+| [apilayer pdflayer](https://pdflayer.com) | HTML/URL을 PDF로 | `apiKey` | Yes | Unknown |
+| [Asana](https://developers.asana.com/docs) | Asana 시스템의 모든 데이터에 프로그래밍 방식으로 액세스 | `apiKey` | Yes | Yes |
+| [BuildPDF](https://buildpdf.co/api/docs) | HTML, 이미지, 텍스트를 PDF로 변환 | `apiKey` | Yes | Yes |
+| [ClickUp](https://clickup.com/api) | ClickUp은 생산성 향상을 위한 강력한 클라우드 기반 프로젝트 관리 도구입니다. | `OAuth` | Yes | Unknown |
+| [Clockify](https://clockify.me/developers-api) | Clockify의 REST 기반 API를 사용하여 데이터를 푸시/풀하고 다른 시스템과 통합할 수 있습니다. | `apiKey` | Yes | Unknown |
+| [CloudConvert](https://cloudconvert.com/api/v2) | 오디오, 비디오, 문서, 전자책, 아카이브, 이미지, 스프레드시트, 프리젠테이션을 위한 온라인 파일 변환기 | `apiKey` | Yes | Unknown |
+| [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL을 PDF/PNG로, Office 문서를 PDF로, 이미지 변환 | `apiKey` | Yes | Yes |
+| [Code::Stats](https://codestats.net/api-docs) | 프로그래머를 위한 자동 시간 추적 | `apiKey` | Yes | No |
+| [CraftMyPDF](https://craftmypdf.com) | 드롭 앤 드롭 편집기와 간단한 API를 사용하여 템플릿에서 PDF 문서 생성 | `apiKey` | Yes | No |
+| [Flowdash](https://docs.flowdash.com/docs/api-introduction) | 비즈니스 워크플로 자동화 | `apiKey` | Yes | Unknown |
+| [Html2PDF](https://html2pdf.app/) | HTML/URL을 PDF로 | `apiKey` | Yes | Unknown |
+| [iLovePDF](https://developer.ilovepdf.com/) | PDF의 변환, 병합, 분할, 텍스트 추출 및 페이지 번호 추가. 월 250개 문서 무료 | `apiKey` | Yes | Yes |
+| [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/) | JIRA는 버그 추적 및 민첩한 프로젝트 관리를 가능하게 하는 독점 문제 추적 제품입니다. | `OAuth` | Yes | Unknown |
+| [Mattermost](https://api.mattermost.com/) | 개발자 협업을 위한 오픈 소스 플랫폼 | `OAuth` | Yes | Unknown |
+| [Mercury](https://mercury.postlight.com/web-parser/) | 웹 파서 | `apiKey` | Yes | Unknown |
+| [Monday](https://api.developer.monday.com/docs) | Monday.com 계정 내 데이터에 프로그래밍 방식으로 액세스하고 업데이트합니다. | `apiKey` | Yes | Unknown |
+| [Notion](https://developers.notion.com/docs/getting-started) | 노션과 통합 | `OAuth` | Yes | Unknown |
+| [PandaDoc](https://developers.pandadoc.com) | DocGen 및 전자 서명 API | `apiKey` | Yes | No |
+| [Pocket](https://getpocket.com/developer/) | 북마크 서비스 | `OAuth` | Yes | Unknown |
+| [Podio](https://developers.podio.com) | 파일 공유 및 생산성 | `OAuth` | Yes | Unknown |
+| [PrexView](https://prexview.com) | XML 또는 JSON에서 PDF, HTML 또는 이미지로 데이터 변환 | `apiKey` | Yes | Unknown |
+| [Restpack](https://restpack.io/) | 스크린샷, HTML to PDF 및 콘텐츠 추출 API 제공 | `apiKey` | Yes | Unknown |
+| [Todoist](https://developer.todoist.com) | 할 일 목록 | `OAuth` | Yes | Unknown |
+| [Smart Image Enhancement API](https://apilayer.com/marketplace/image_enhancement-api) | 여러 초해상도 알고리즘을 통해 이미지에 디테일을 추가하여 이미지 업스케일링 수행 | `apiKey` | Yes | Unknown |
+| [staffSign](https://staffsign.de/docs) | HR 및 직원 배치를 위한 QES/eIDAS 지원을 갖춘 디지털 고용 계약 API | `apiKey` | Yes | Yes |
+| [Vector Express v2.0](https://vector.express) | 무료 벡터 파일 변환 API | No | Yes | No |
+| [WakaTime](https://wakatime.com/developers) | 프로그래머를 위한 자동화된 시간 추적 리더보드 | No | Yes | Unknown |
+| [Zube](https://zube.io/docs/api) | 풀스택 프로젝트 관리 | `OAuth` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
-### 교육
+### 이메일
 
-|                                        API                                         | 설명                                                  |   인증   | HTTPS |  CORS  |
-| :--------------------------------------------------------------------------------: | ----------------------------------------------------- | :------: | :---: | :----: |
-| [Current Affairs](https://rapidapi.com/malaithiru370/api/current-affairs-of-india) | 현재 국제 정세, 퀴즈 등                               | `apiKey` |  Yes  |   No   |
-|                    [NationNode](https://nationnode.vercel.app)                     | 국가에 대한 특정 세부 정보 조회                       |    No    |  Yes  |  Yes   |
-|                 [Secrets-APi](https://secrets-api.appbrewery.com/)                 | 학습 목적으로 사용, 이 API로 모든 보안 유형 학습      |   All    |  Yes  | Unkown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [mailboxlayer](https://mailboxlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 이메일 주소 확인 | `apiKey` | Yes | Unknown |
+| [Cloudmersive Validate](https://cloudmersive.com/validate-api) | 이메일 주소, 전화번호, VAT 번호 및 도메인 이름 검증 | `apiKey` | Yes | Yes |
+| [Disify](https://www.disify.com/) | 일회용 및 임시 이메일 주소를 검증하고 감지합니다. | No | Yes | Yes |
+| [DropMail](https://dropmail.me/api/#live-demo) | 임시 이메일 받은 편지함을 생성하고 관리하기 위한 GraphQL API | No | Yes | Unknown |
+| [EmailJS](https://www.emailjs.com/docs/) | 백엔드 서버 없이 클라이언트 측 JavaScript에서 직접 이메일 보내기 | `apiKey` | Yes | Yes |
+| [Email Validation](https://www.abstractapi.com/email-verification-validation-api) | 배달 가능성 및 스팸에 대한 이메일 주소의 유효성을 검사합니다. | `apiKey` | Yes | Yes |
+| [EVA](https://eva.pingutil.com/) | 이메일 주소 확인 | No | Yes | Yes |
+| [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | 일회용 임시 이메일 주소 | No | Yes | Unknown |
+| [ImprovMX](https://improvmx.com/api) | 무료 이메일 전달 서비스를 위한 API | `apiKey` | Yes | Unknown |
+| [Kickbox](https://open.kickbox.com/) | 이메일 확인 API | No | Yes | Yes |
+| [mail.gw](https://docs.mail.gw) | 10분 메일 | No | Yes | Yes |
+| [mail.tm](https://docs.mail.tm) | 임시 이메일 서비스 | No | Yes | Yes |
+| [MailboxValidator](https://www.mailboxvalidator.com/api-email-free) | 전달 가능성을 높이기 위해 이메일 주소를 검증하세요 | `apiKey` | Yes | Unknown |
+| [MailCheck.ai](https://www.mailcheck.ai/#documentation) | 사용자가 임시 이메일 주소로 가입하는 것을 방지 | No | Yes | Unknown |
+| [Mailtrap](https://mailtrap.docs.apiary.io/#) | 개발 및 스테이징 환경에서 전송된 이메일을 안전하게 테스트하기 위한 서비스 | `apiKey` | Yes | Unknown |
+| [PostStack](https://poststack.dev/docs) | 연락처, 방송 및 분석 기능이 포함된 거래 및 마케팅 이메일을 위한 EU 호스팅 이메일 API | `apiKey` | Yes | No |
+| [Sendgrid](https://docs.sendgrid.com/api-reference/) | 이메일 서버를 유지 관리할 필요 없이 이메일을 보낼 수 있는 클라우드 기반 SMTP 공급자 | `apiKey` | Yes | Unknown |
+| [Sendinblue](https://developers.sendinblue.com/docs) | 마케팅 및/또는 거래 이메일 및/또는 SMS와 관련된 솔루션을 제공하는 서비스 | `apiKey` | Yes | Unknown |
+| [Verifier](https://verifier.meetchopra.com/docs#/) | 주어진 이메일이 진짜인지 확인합니다. | `apiKey` | Yes | Yes |
+
+**[⬆ 목차로 돌아가기](#목차)**
+
+### 엔터테인먼트
+
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Anycrap](https://anycrap.shop/developers) | 이름, 설명, 이미지가 포함된 35,000개 이상의 터무니없는 AI 생성 제품 컨셉 | `apiKey` | Yes | Yes |
+| [chucknorris.io](https://api.chucknorris.io) | 수작업으로 큐레이션된 척 노리스 농담을 위한 JSON API | No | Yes | Unknown |
+| [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | 기업 버즈 워드용 REST API | No | Yes | Yes |
+| [Excuser](https://excuser.herokuapp.com/) | 다양한 상황에 대해 무작위로 변명하기 | No | Yes | Unknown |
+| [Fun Fact](https://api.aakhilv.me) | FFA 데이터베이스에서 사실을 무작위로 선택하고 반환할 수 있는 간단한 HTTPS API | No | Yes | Yes |
+| [Imgflip](https://imgflip.com/api) | 다양한 인기 밈을 가져옵니다. | No | Yes | Unknown |
+| [Meme Maker](https://mememaker.github.io/API/) | 나만의 밈을 만들기 위한 REST API | No | Yes | Unknown |
+| [Memesio](https://memesio.com/developers/api) | 템플릿, 편집 가능한 캡션, 호스팅된 공유 링크가 포함된 Meme 생성 API | No | Yes | No |
+| [NaMoMemes](https://github.com/theIYD/NaMoMemes) | 나렌드라 모디에 대한 밈 | No | Yes | Unknown |
+| [Random Useless Facts](https://uselessfacts.jsph.pl/) | 쓸모없지만 사실은 사실입니다 | No | Yes | Unknown |
+| [TasteDive](https://tastedive.com/read/api) | 유사한 아티스트 API (영화 및 TV 쇼에도 작동) | `apiKey` | Yes | No |
+| [Techy](https://techy-api.vercel.app/) | 기술에 정통한 표현을 위한 JSON 및 일반 텍스트 API | No | Yes | Unknown |
+| [Yo Momma Jokes](https://github.com/beanboi7/yomomma-apiv2) | Yo Momma Jokes를 위한 REST API | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 환경
 
-|                                                  API                                                   | 설명                                                          |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------------------------------------------------------------: | ------------------------------------------------------------- | :------: | :---: | :-----: |
-|                                 [AirVisual](https://airvisual.com/api)                                 | 대기질 및 날씨 데이터                                         | `apiKey` |  Yes  | Unknown |
-|                                   [OpenAQ](https://docs.openaq.org/)                                   | 공개 대기질 데이터                                            | `apiKey` |  Yes  | Unknown |
-|                                     [AQICN](http://aqicn.org/api)                                      | 실시간 대기질 지수                                            | `apiKey` |  No   | Unknown |
-|                      [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/)                      | 태양광(PV) 에너지 시스템의 에너지 생산                        | `apiKey` |  Yes  | Unknown |
-| [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | National Grid에서 개발한 영국 공식 탄소 집약도 API            |    No    |  Yes  | Unknown |
-|                 [NOAA Climate Data](https://www.ncdc.noaa.gov/cdo-web/webservices/v2)                  | 국립 해양 대기청의 공식 기후 데이터 API                       | `apiKey` |  Yes  | Unknown |
-|                         [WeatherStack](https://weatherstack.com/documentation)                         | 습도 및 대기 및 압력 API                                      | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [BreezoMeter Pollen](https://docs.breezometer.com/api-documentation/pollen-api/v2/) | 특정 위치의 일일 예보 꽃가루 상태 데이터 | `apiKey` | Yes | Unknown |
+| [Carbon Interface](https://docs.carboninterface.com/) | 일반적인 CO2 배출 활동에 대한 탄소(C02) 배출 추정치를 계산하는 API | `apiKey` | Yes | Yes |
+| [Climatiq](https://docs.climatiq.io) | 광범위한 배출 생성 활동으로 인해 발생하는 환경 발자국을 계산합니다. | `apiKey` | Yes | Yes |
+| [Cloverly](https://www.cloverly.com/carbon-offset-documentation) | API는 일반적인 탄소 집약적 활동의 영향을 실시간으로 계산합니다. | `apiKey` | Yes | Unknown |
+| [CO2 Offset](https://co2offset.io/api.html) | API는 탄소 발자국을 계산하고 검증합니다. | No | Yes | Unknown |
+| [Danish data service Energi](https://www.energidataservice.dk/) | Energinet의 에너지 데이터를 사회에 공개 | No | Yes | Unknown |
+| [GrünstromIndex](https://gruenstromindex.de/) | 독일 그린 파워 지수(Grünstromindex/GSI) | No | No | Yes |
+| [IQAir](https://www.iqair.com/air-pollution-data-api) | 대기 질 및 날씨 데이터 | `apiKey` | Yes | Unknown |
+| [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/) | 네덜란드(RIVM)의 예측 및 실제 대기질 구성요소 | No | Yes | Unknown |
+| [National Grid ESO](https://data.nationalgrideso.com/) | 영국 전력 시스템 운영자의 공개 데이터 | No | Yes | Unknown |
+| [OpenAQ](https://docs.openaq.org/) | 공개 대기질 데이터 | `apiKey` | Yes | Unknown |
+| [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | 저가형 PM2.5 센서 데이터 공개 | No | Yes | Unknown |
+| [PM25.in](http://www.pm25.in/api_doc) | 중국의 대기질 | `apiKey` | No | Unknown |
+| [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | 태양광(PV) 에너지 시스템의 에너지 생산 | `apiKey` | Yes | Unknown |
+| [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Srp 고객을 위한 시간별 사용량 에너지 보고서 | `apiKey` | Yes | No |
+| [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | National Grid에서 개발한 영국 공식 탄소 집약도 API | No | Yes | Unknown |
+| [Website Carbon](https://api.websitecarbon.com/) | 웹 페이지 로딩의 탄소 배출량을 추정하는 API | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 이벤트
 
-|                                            API                                            | 설명                             |   인증   | HTTPS |  CORS   |
-| :---------------------------------------------------------------------------------------: | -------------------------------- | :------: | :---: | :-----: |
-|                  [Eventbrite](https://www.eventbrite.com/developer/v3/)                   | 이벤트 찾기                      | `OAuth`  |  Yes  | Unknown |
-|                        [SeatGeek](https://platform.seatgeek.com/)                         | 이벤트, 장소 및 공연자 검색      | `apiKey` |  Yes  | Unknown |
-| [Ticketmaster](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/) | 이벤트, 명소 또는 장소 검색      | `apiKey` |  Yes  | Unknown |
-|                      [Songkick](https://www.songkick.com/developer)                       | 예정된 콘서트 API                | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Eventbrite](https://www.eventbrite.com/platform/api/) | 이벤트 찾기 | `OAuth` | Yes | Unknown |
+| [SeatGeek](https://platform.seatgeek.com/) | 이벤트, 장소 및 공연자 검색 | `apiKey` | Yes | Unknown |
+| [Ticketmaster](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/) | 이벤트, 명소 또는 장소 검색 | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 금융
 
-|                                   API                                    | 설명                                                   |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------------------------------: | ------------------------------------------------------------- | :------: | :---: | :-----: |
-|              [Alpha Vantage](https://www.alphavantage.co/)               | 실시간 및 과거 주식 데이터                            | `apiKey` |  Yes  | Unknown |
-|        [Barchart OnDemand](https://www.barchartondemand.com/free)        | 주식, 선물, 외환 시장 데이터                          | `apiKey` |  Yes  | Unknown |
-|               [Financial Data](https://financialdata.net/)               | 주식 시장 및 금융 데이터                               | `apiKey` |  Yes  | Unknown |
-|      [Financial Modeling Prep](https://financialmodelingprep.com/)       | 주식 정보 및 데이터                                    | `apiKey` |  Yes  | Unknown |
-|             [Fincept Insights](https://insights.fincept.in/)             | 금융 시장, 경제, 뉴스 데이터 및 분석            | `apiKey` |  Yes  | Unknown |
-|                 [IEX](https://iextrading.com/developer/)                 | 실시간 주식 데이터                                           | `apiKey` |  Yes  |   Yes   |
-|                    [IEX Cloud](https://iexcloud.io/)                     | 실시간 및 과거 주식과 시장 데이터                   | `apiKey` |  Yes  |   Yes   |
-|                 [IG](https://labs.ig.com/gettingstarted)                 | 스프레드 베팅 및 CFD 시장 데이터                             | `apiKey` |  Yes  | Unknown |
-|                       [Plaid](https://plaid.com/)                        | 사용자의 은행 계좌 연결 및 거래 데이터 접근 | `apiKey` |  Yes  | Unknown |
-|               [Razorpay IFSC](https://ifsc.razorpay.com/)                | 인도 금융 시스템 코드 (은행 지점 코드)             |    No    |  Yes  | Unknown |
-| [Indian Bank Data API](https://github.com/kaustubhk24/Indian-Banks-Data) | 모든 은행 IFSC 코드 데이터, IFSC나 기타 세부정보로 검색      |    No    |  Yes  | Unknown |
-|                 [Tradier](https://developer.tradier.com)                 | 미국 주식/옵션 시장 데이터 (지연, 당일, 과거)  | `OAuth`  |  Yes  |   Yes   |
-|         [World Trading Data](https://www.worldtradingdata.com/)          | 시장 데이터 제공업체                                          | `apiKey` |  Yes  | Unknown |
-|                 [YNAB](https://api.youneedabudget.com/)                  | 예산 및 계획                                          | `OAuth`  |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Marketstack](https://marketstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 실시간, 일중 및 과거 시장 데이터 API | `apiKey` | Yes | Unknown |
+| [Aletheia](https://aletheiaapi.com/) | 내부자 거래 데이터, 수입 분석, 재무제표 등 | `apiKey` | Yes | Yes |
+| [Alpaca](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/) | 모든 미국 주식 및 ETF에 대한 실시간 및 과거 시장 데이터 | `apiKey` | Yes | Yes |
+| [Alpha Vantage](https://www.alphavantage.co/) | 실시간 및 과거 주식 데이터 | `apiKey` | Yes | Unknown |
+| [Banco do Brasil](https://developers.bb.com.br/home) | 모든 Banco do Brasil 금융 거래 API | `OAuth` | Yes | Yes |
+| [Bank Data API](https://apilayer.com/marketplace/bank_data-api) | 전 세계적으로 즉각적인 IBAN 및 SWIFT 번호 확인 | `apiKey` | Yes | Unknown |
+| [Billplz](https://www.billplz.com/api) | 결제 플랫폼 | `apiKey` | Yes | Unknown |
+| [Binlist](https://binlist.net/) | IIN/BIN 정보 데이터베이스에 대한 공개 액세스 | No | Yes | Unknown |
+| [Boleto.Cloud](https://boleto.cloud/) | 브라질에서 boleto를 생성하는 API | `apiKey` | Yes | Unknown |
+| [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | 모든 Citigroup 계좌 및 명세서 데이터 API | `apiKey` | Yes | Unknown |
+| [Econdb](https://www.econdb.com/api/) | 글로벌 거시경제 데이터 | No | Yes | Yes |
+| [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | 미국 재무부 데이터 | No | Yes | Unknown |
+| [Finage](https://finage.co.uk) | Finage는 주식, 통화, 암호화폐, 지수, ETF 실시간 및 과거 데이터 제공업체입니다. | `apiKey` | Yes | Unknown |
+| [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | 실시간 및 과거 주식 데이터 | `apiKey` | Yes | Unknown |
+| [Finnhub](https://finnhub.io/docs/api) | 주식, 통화, 암호화폐를 위한 실시간 RESTful API 및 웹소켓 | `apiKey` | Yes | Unknown |
+| [FRED](https://fred.stlouisfed.org/docs/api/fred/) | 세인트루이스 연방준비은행의 경제 데이터 | `apiKey` | Yes | Yes |
+| [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front Accounting은 중소기업을 위한 다국어 및 다중 통화 소프트웨어입니다. | `OAuth` | Yes | Yes |
+| [Helium](https://heliumtrades.com/mcp-page/) | 미디어 편견 점수, 균형 잡힌 뉴스 종합, 실시간 시장 데이터, AI 옵션 가격 책정이 포함된 뉴스 | No | Yes | Yes |
+| [Hotstoks](https://hotstoks.com?utm_source=public-apis) | SQL로 구동되는 주식 시장 데이터 | `apiKey` | Yes | Yes |
+| [IBANforge](https://api.ibanforge.com) | 121,000개 이상의 은행 항목이 있는 75개 이상의 국가에 대한 IBAN 검증 및 BIC/SWIFT 조회 | No | Yes | Yes |
+| [IEX Cloud](https://iexcloud.io/docs/api/) | 실시간 및 과거 주식 및 시장 데이터 | `apiKey` | Yes | Yes |
+| [IG](https://labs.ig.com/gettingstarted) | 스프레드 베팅 및 CFD 시장 데이터 | `apiKey` | Yes | Unknown |
+| [Indian Mutual Fund](https://www.mfapi.in/) | 인도 뮤추얼 펀드 데이터의 전체 내역을 확인하세요 | No | Yes | Unknown |
+| [Intrinio](https://intrinio.com/) | 다양한 금융 데이터 피드 선택 | `apiKey` | Yes | Unknown |
+| [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna 결제 및 쇼핑 서비스 | `apiKey` | Yes | Unknown |
+| [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API 참조 - 통합을 개발하는 데 필요한 모든 정보 | `apiKey` | Yes | Unknown |
+| [Mono](https://mono.co/) | 사용자의 은행 계좌에 연결하고 아프리카의 거래 데이터에 액세스하세요. | `apiKey` | Yes | Unknown |
+| [Moov](https://docs.moov.io/api/) | Moov API를 사용하면 플랫폼에서 돈을 보내고 받고 저장할 수 있습니다. | `apiKey` | Yes | Unknown |
+| [Nordigen](https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/) | 공식 은행 API를 사용하여 은행 계좌에 연결하고 원시 거래 데이터를 가져옵니다. | `apiKey` | Yes | Unknown |
+| [OpenFIGI](https://www.openfigi.com/api) | Bloomberg LP의 주식, 지수, 선물, 옵션 기호 | `apiKey` | Yes | Yes |
+| [Plaid](https://www.plaid.com/docs) | 사용자의 은행 계좌에 연결하고 거래 데이터에 액세스합니다. | `apiKey` | YES |  |
+| [Polygon](https://polygon.io/) | 과거 주식 시장 데이터 | `apiKey` | Yes | Unknown |
+| [Portfolio Optimizer](https://portfoliooptimizer.io/) | 포트폴리오 분석 및 최적화 | No | Yes | Yes |
+| [Razorpay IFSC](https://razorpay.com/docs/) | 인도 금융 시스템 코드(은행 지점 코드) | No | Yes | Unknown |
+| [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | 실시간 주식 데이터에 액세스하는 Websocket API | `apiKey` | No | Unknown |
+| [SEC EDGAR Data](https://www.sec.gov/edgar/sec-api-documentation) | 미국 상장 기업의 연간 보고서에 액세스하기 위한 API | No | Yes | Yes |
+| [SmartAPI](https://smartapi.angelbroking.com/) | <SmartAPI> 세트에 접근하여 엔드투엔드 브로커 서비스 생성 | `apiKey` | Yes | Unknown |
+| [StockData](https://www.StockData.org) | 실시간, 일중 및 과거 시장 데이터, 뉴스 및 감정 API | `apiKey` | Yes | Yes |
+| [Styvio](https://www.Styvio.com) | 실시간 및 과거 주식 데이터와 현재 주식 심리 | `apiKey` | Yes | Unknown |
+| [Tax Data API](https://apilayer.com/marketplace/tax_data-api) | 전 세계적으로 즉각적인 VAT 번호 및 세금 확인 | `apiKey` | Yes | Unknown |
+| [Tradier](https://developer.tradier.com) | 미국 주식/옵션 시장 데이터 (지연, 당일, 과거) | `OAuth` | Yes | Yes |
+| [Twelve Data](https://twelvedata.com/) | 주식 시장 데이터(실시간 및 과거) | `apiKey` | Yes | Unknown |
+| [VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | VAT 번호 확인 및 VAT 세율 계산 | `apiKey` | Yes | Yes |
+| [WallstreetBets](https://dashboard.nbshare.io/apps/reddit/api/) | WallstreetBets 주식 댓글 감정 분석 | No | Yes | Unknown |
+| [Yahoo Finance](https://www.yahoofinanceapi.com/) | 주식 시장, 암호화폐 및 환전을 위한 실시간 저지연 Yahoo Finance API | `apiKey` | Yes | Yes |
+| [YNAB](https://api.youneedabudget.com/) | 예산 및 계획 | `OAuth` | Yes | Yes |
+| [Zoho Books](https://www.zoho.com/books/api/v3/) | 귀하의 비즈니스를 위해 제작된 온라인 회계 소프트웨어 | `OAuth` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 음식 & 음료
 
-|                                       API                                        | 설명                                        |   인증   | HTTPS |  CORS   |
-| :------------------------------------------------------------------------------: | ------------------------------------------- | :------: | :---: | :-----: |
-|                     [Edamam](https://developer.edamam.com/)                      | 레시피 검색                                 | `apiKey` |  Yes  | Unknown |
-|                           [LCBO](https://lcboapi.com/)                           | 주류                                        | `apiKey` |  Yes  | Unknown |
-|                 [Open Brewery DB](https://www.openbrewerydb.org)                 | 양조장, 사과주 양조장 및 수제 맥주 병 상점  |    No    |  Yes  |   Yes   |
-|             [Open Food Facts](https://world.openfoodfacts.org/data)              | 식품 제품 데이터베이스                      |    No    |  Yes  | Unknown |
-|                   [PunkAPI](https://github.com/alxiw/punkapi)                    | BrewDog의 DIY Dog 맥주 카탈로그 API         |    No    |  Yes  |   Yes   |
-|                 [Spoonacular](https://spoonacular.com/food-api)                  | 음식 및 레시피                              | `apikey` |  Yes  | Unknown |
-|                [TacoFancy](https://github.com/evz/tacofancy-api)                 | 커뮤니티 기반 타코 데이터베이스             |    No    |  No   | Unknown |
-| [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | 음식 및 음료 리뷰                           |    No    |  Yes  | Unknown |
-|                        [BoozeAPI](https://boozeapi.com/)                         | REST API 칵테일 레시피                      | `apiKey` |  Yes  |   Yes   |
-|              [TheCocktailDB](https://www.thecocktaildb.com/api.php)              | 칵테일 레시피                               | `apiKey` |  Yes  |   Yes   |
-|                  [TheMealDB](https://www.themealdb.com/api.php)                  | 식사 레시피                                 | `apiKey` |  Yes  |   Yes   |
-|             [What's on the menu?](http://nypl.github.io/menus-api/)              | NYPL 사람이 전사한 역사적 메뉴 컬렉션       | `apiKey` |  No   | Unknown |
-|                  [WhiskyHunter](https://whiskyhunter.net/api/)                   | 과거 온라인 위스키 경매 통계 데이터         |    No    |  Yes  | Unknown |
-|                       [Zestful](https://zestfuldata.com/)                        | 레시피 재료 파싱                            | `apiKey` |  Yes  |   Yes   |
-
-**[⬆ 목차로 돌아가기](#목차)**
-
-### 사기 방지
-
-|                                   API                                    | 설명                                                                                                 |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------------------------------: | ---------------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-| [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order) | AI를 사용하여 사기를 탐지하는 주문 정보 심사                                                         | `apiKey` |  Yes  | Unknown |
-|                [Jumio](https://www.jumio.com/developer/)                 | 문서 검증 및 생체 인증을 포함한 신원 확인, KYC, AML 솔루션 제공                                      | `apiKey` |  Yes  | Unknown |
-|                 [Onfido](https://onfido.com/developers/)                 | 문서 검증 및 얼굴 인식을 포함한 신원 확인 및 신원조회 서비스 제공                                    | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [BaconMockup](https://baconmockup.com/) | 크기 조정 가능한 베이컨 자리 표시자 이미지 | No | Yes | Yes |
+| [Chomp](https://chompthis.com/api/) | 다양한 식료품 및 식품에 대한 데이터 | `apiKey` | Yes | Unknown |
+| [Coffee](https://coffee.alexflipnote.dev/) | 커피의 무작위 사진 | No | Yes | Unknown |
+| [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api) | 영양 분석 | `apiKey` | Yes | Unknown |
+| [Edamam recipes](https://developer.edamam.com/edamam-docs-recipe-api) | 레시피 검색 | `apiKey` | Yes | Unknown |
+| [Foodish](https://github.com/surhud004/Foodish#readme) | 음식 요리의 무작위 사진 | No | Yes | Yes |
+| [Fruityvice](https://www.fruityvice.com) | 모든 종류의 과일에 대한 데이터 | No | Yes | Unknown |
+| [Kroger](https://developer.kroger.com/reference) | 슈퍼마켓 데이터 | `apiKey` | Yes | Unknown |
+| [LCBO](https://lcboapi.com/) | 주류 | `apiKey` | Yes | Unknown |
+| [Open Brewery DB](https://www.openbrewerydb.org) | 양조장, 사과주 양조장 및 수제 맥주 병 상점 | No | Yes | Yes |
+| [Open Food Facts](https://world.openfoodfacts.org/data) | 식품 제품 데이터베이스 | No | Yes | Unknown |
+| [PunkAPI](https://punkapi.com/) | 브루독 맥주 레시피 | No | Yes | Unknown |
+| [RecipeAPI](https://recipeapi.io) | 조리법, 재료, 영양 데이터 및 요리 지침 | `apiKey` | Yes | Yes |
+| [Rustybeer](https://rustybeer.herokuapp.com/) | 맥주 양조 도구 | No | Yes | No |
+| [Spoonacular](https://spoonacular.com/food-api) | 음식 및 레시피 | `apiKey` | Yes | Unknown |
+| [Systembolaget](https://api-portal.systembolaget.se) | 스웨덴의 정부 소유 주류 판매점 | `apiKey` | Yes | Unknown |
+| [TacoFancy](https://github.com/evz/tacofancy-api) | 커뮤니티 기반 타코 데이터베이스 | No | No | Unknown |
+| [Tasty](https://rapidapi.com/apidojo/api/tasty/) | 레시피, 계획, 재료에 대한 데이터를 쿼리하는 API | `apiKey` | Yes | Unknown |
+| [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | 음식 및 음료 리뷰 | No | Yes | Unknown |
+| [TheCocktailDB](https://www.thecocktaildb.com/api.php) | 칵테일 레시피 | `apiKey` | Yes | Yes |
+| [TheMealDB](https://www.themealdb.com/api.php) | 식사 레시피 | `apiKey` | Yes | Yes |
+| [Untappd](https://untappd.com/api/docs) | 소셜 맥주 공유 | `OAuth` | Yes | Unknown |
+| [What's on the menu?](http://nypl.github.io/menus-api/) | NYPL 사람이 전사한 역사적 메뉴 컬렉션 | `apiKey` | No | Unknown |
+| [WhiskyHunter](https://whiskyhunter.net/api/) | 과거 온라인 위스키 경매 통계 데이터 | No | Yes | Unknown |
+| [Zestful](https://zestfuldata.com/) | 레시피 재료 파싱 | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 게임 & 만화
 
-|                                      API                                      | 설명                                                                                 |      인증       | HTTPS |  CORS   |
-| :---------------------------------------------------------------------------: | ------------------------------------------------------------------------------------ | :-------------: | :---: | :-----: |
-|                    [AmiiboAPI](http://www.amiiboapi.com/)                     | Amiibo 정보                                                                          |       No        |  No   |   Yes   |
-|                     [Battle.net](https://dev.battle.net/)                     | 블리자드 엔터테인먼트                                                                |    `apiKey`     |  Yes  | Unknown |
-|          [Blue Archive](https://github.com/arufars/api-blue-archive)          | 블루 아카이브 게임 데이터 API 캐릭터                                                 |       No        |  Yes  | Unknown |
-|              [Chuck Norris Database](http://www.icndb.com/api/)               | 농담                                                                                 |       No        |  No   | Unknown |
-|             [Clash of Clans](https://developer.clashofclans.com)              | 클래시 오브 클랜 게임 정보                                                           |    `apiKey`     |  Yes  | Unknown |
-|               [Clash Royale](https://developer.clashroyale.com)               | 클래시 로얄 게임 정보                                                                |    `apiKey`     |  Yes  | Unknown |
-|        [Comic Vine](https://comicvine.gamespot.com/api/documentation)         | 만화                                                                                 |       No        |  Yes  | Unknown |
-|              [Cross Universe](https://crossuniverse.net/apiDocs)              | Cross Universe 카드 데이터                                                           |       No        |  Yes  |   Yes   |
-|                  [Deck of Cards](http://deckofcardsapi.com/)                  | 카드 덱                                                                              |       No        |  No   | Unknown |
-|             [Destiny The Game](https://github.com/Bungie-net/api)             | Bungie 플랫폼 API                                                                    |    `apiKey`     |  Yes  | Unknown |
-|                     [Dota 2](https://docs.opendota.com/)                      | 플레이어 통계, 매치 통계, Dota 2 랭킹 정보 제공                                      |       No        |  Yes  | Unknown |
-|                [Dungeons and Dragons](http://www.dnd5eapi.co/)                | 5판 주문, 클래스, 몬스터 등에 대한 참조                                              |       No        |  No   |   No    |
-|                  [Eight Ball API](https://eightballapi.com/)                  | 랜덤, 감정 편향, 다국어 응답이 포함된 운세 API                                       |       No        |  Yes  |   Yes   |
-|                   [Eve Online](https://esi.evetech.net/ui)                    | 제3자 개발자 문서                                                                    |     `OAuth`     |  Yes  | Unknown |
-|                   [Final Fantasy XIV](https://xivapi.com/)                    | 파이널 판타지 XIV 게임 데이터 API                                                    |       No        |  Yes  |   Yes   |
-|                     [Fortnite](https://fortniteapi.com/)                      | 포트나이트 통계 및 코스메틱                                                          |    `apiKey`     |  Yes  |   Yes   |
-|        [Fortnite](https://tracker.gg/developers/docs/getting-started)         | 포트나이트 통계                                                                      |    `apiKey`     |  Yes  | Unknown |
-|           [Giant Bomb](https://www.giantbomb.com/api/documentation)           | 비디오 게임                                                                          |       No        |  Yes  | Unknown |
-|           [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main)           | 길드워 2 게임 정보                                                                   |    `apiKey`     |  Yes  | Unknown |
-|                    [Halo](https://developer.haloapi.com/)                     | Halo 5 및 Halo Wars 2 정보                                                          |    `apiKey`     |  Yes  | Unknown |
-|                   [Hearthstone](http://hearthstoneapi.com/)                   | 하스스톤 카드 정보                                                                   | `X-Mashape-Key` |  Yes  | Unknown |
-|                      [Hypixel](https://api.hypixel.net/)                      | Hypixel 플레이어 통계                                                                |    `apiKey`     |  Yes  | Unknown |
-|                       [IGDB.com](https://api.igdb.com/)                       | 비디오 게임 데이터베이스                                                             |    `apiKey`     |  Yes  | Unknown |
-|                   [Jokes One](https://jokes.one/api/joke/)                    | 오늘의 농담 및 REST API를 통해 접근 가능한 대규모 농담 카테고리                       |    `apiKey`     |  Yes  |   Yes   |
-|                   [JokeAPI](https://sv443.net/jokeapi/v2/)                    | 프로그래밍, 기타 및 다크 유머                                                        |       No        |  Yes  |   Yes   |
-|             [Jokes](https://github.com/15Dkatz/official_joke_api)             | 프로그래밍 및 일반 농담                                                              |       No        |  Yes  | Unknown |
-|                        [Jservice](http://jservice.io)                         | 제오파디 질문 데이터베이스                                                           |       No        |  No   | Unknown |
-|              [Magic The Gathering](http://magicthegathering.io/)              | 매직 더 개더링 게임 정보                                                             |       No        |  No   | Unknown |
-|                     [Marvel](http://developer.marvel.com)                     | 마블 코믹스                                                                          |    `apiKey`     |  No   | Unknown |
-|                         [mod.io](https://docs.mod.io)                         | 크로스 플랫폼 모드 API                                                               |    `apiKey`     |  Yes  | Unknown |
-|               [Open Trivia](https://opentdb.com/api_config.php)               | 퀴즈 질문                                                                            |       No        |  Yes  | Unknown |
-|                    [PandaScore](https://api.pandascore.co)                    | e스포츠 게임 및 결과                                                                 |    `apiKey`     |  Yes  | Unknown |
-|        [PlayerUnknown's Battlegrounds](https://tracker.gg/developers)         | PUBG 통계                                                                            |    `apiKey`     |  Yes  | Unknown |
-| [Pokémon-3D-api ](https://documenter.getpostman.com/view/29725199/2sAYX8KMU8) | ThreeJS용 3D 포켓몬 모델                                                             |       No        |  Yes  |   Yes   |
-|                         [Pokéapi](https://pokeapi.co)                         | 포켓몬 정보                                                                          |       No        |  Yes  | Unknown |
-|                     [Pokémon TCG](https://pokemontcg.io)                      | 포켓몬 TCG 정보                                                                      |       No        |  Yes  | Unknown |
-|             [Random Facts](https://fungenerators.com/api/facts/)              | 수백 개 카테고리의 랜덤 팩트                                                         |    `apiKey`     |  Yes  |   Yes   |
-|                 [Rick and Morty](https://rickandmortyapi.com)                 | 이미지를 포함한 모든 릭 앤 모티 정보                                                 |       No        |  Yes  |   Yes   |
-|                [Riot Games](https://developer.riotgames.com/)                 | 리그 오브 레전드 게임 정보                                                           |    `apiKey`     |  Yes  | Unknown |
-|            [Scoresaber](https://scoresaber.com/api/documentation)             | Scoresaber 통계                                                                      |       No        |  Yes  | Unknown |
-|                   [Scryfall](https://scryfall.com/docs/api)                   | 매직: 더 개더링 데이터베이스                                                         |       No        |  Yes  |   Yes   |
-|        [Steam](https://developer.valvesoftware.com/wiki/Steam_Web_API)        | Steam 클라이언트 상호작용                                                            |     `OAuth`     |  Yes  | Unknown |
-|                    [SuperHeroes](https://superheroapi.com)                    | 단일 API 하에 모든 우주의 모든 슈퍼히어로 및 빌런 데이터                             |    `apiKey`     |  Yes  | Unknown |
-|                       [TCGdex](https://www.tcgdex.dev/)                       | 카드 사진과 카드에 포함된 대부분의 정보가 있는 다국어 포켓몬 TCG 데이터베이스        |       No        |  Yes  |   Yes   |
-|        [TheGamestracker](https://thegamestracker.com/server-info-api)         | JSON 형식의 게임 서버 정보                                                           |    `apiKey`     |  Yes  |   Yes   |
-|              [Wargaming.net](https://developers.wargaming.net/)               | Wargaming.net 정보 및 통계                                                           |    `apiKey`     |  Yes  |   No    |
-|                      [xkcd](https://xkcd.com/json.html)                       | xkcd 만화를 JSON으로 검색                                                            |       No        |  Yes  |   No    |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [AmiiboAPI](https://amiiboapi.com/) | 닌텐도 아미보 정보 | No | Yes | Yes |
+| [Animal Crossing: New Horizons](http://acnhapi.com/) | 동물, 화석, 예술, 음악, 가구 및 주민을 위한 API | No | Yes | Unknown |
+| [Autochess VNG](https://github.com/didadadida93/autochess-vng-api) | Autochess VNG용 Rest API | No | Yes | Yes |
+| [Barter.VG](https://github.com/bartervg/barter.vg/wiki) | 게임, DLC, 번들, 경품, 거래에 대한 정보를 제공합니다. | No | Yes | Yes |
+| [Battle.net](https://develop.battle.net/documentation/guides/getting-started) | Diablo III, Hearthstone, StarCraft II 및 World of Warcraft 게임 데이터 API | `OAuth` | Yes | Yes |
+| [Board Game Geek](https://boardgamegeek.com/wiki/page/BGG_XML_API2) | 보드 게임, RPG 및 비디오 게임 | No | Yes | No |
+| [Brawl Stars](https://developer.brawlstars.com) | 브롤스타즈 게임 정보 | `apiKey` | Yes | Unknown |
+| [Bugsnax](https://www.bugsnaxapi.com/) | Bugsnax에 대한 정보 얻기 | No | Yes | Yes |
+| [CheapShark](https://www.cheapshark.com/api) | Steam/PC 게임 가격 및 특가 | No | Yes | Yes |
+| [Chess.com](https://www.chess.com/news/view/published-data-api) | Chess.com 읽기 전용 REST API | No | Yes | Unknown |
+| [Chuck Norris Database](http://www.icndb.com/api/) | 농담 | No | No | Unknown |
+| [Clash of Clans](https://developer.clashofclans.com) | 클래시 오브 클랜 게임 정보 | `apiKey` | Yes | Unknown |
+| [Clash Royale](https://developer.clashroyale.com) | 클래시 로얄 게임 정보 | `apiKey` | Yes | Unknown |
+| [Comic Vine](https://comicvine.gamespot.com/api/documentation) | 만화 | No | Yes | Unknown |
+| [Crafatar](https://crafatar.com) | Minecraft 스킨 및 얼굴용 API | No | Yes | Yes |
+| [Cross Universe](https://crossuniverse.psychpsyo.com/apiDocs.html) | 크로스 유니버스 카드 데이터 | No | Yes | Yes |
+| [Deck of Cards](http://deckofcardsapi.com/) | 카드 덱 | No | No | Unknown |
+| [Destiny The Game](https://bungie-net.github.io/multi/index.html) | 번지 플랫폼 API | `apiKey` | Yes | Unknown |
+| [Digimon Information](https://digimon-api.vercel.app/) | 디지몬생물에 대한 정보를 제공합니다. | No | Yes | Unknown |
+| [Digimon TCG](https://documenter.getpostman.com/view/14059948/TzecB4fH) | digimoncard.io에서 디지몬 카드를 검색하세요 | No | Yes | Unknown |
+| [Disney](https://disneyapi.dev) | 디즈니 캐릭터 정보 | No | Yes | Yes |
+| [Dota 2](https://docs.opendota.com/) | 플레이어 통계, 매치 통계, Dota 2 랭킹 정보 제공 | `apiKey` | Yes | Unknown |
+| [Dungeons and Dragons](https://www.dnd5eapi.co/docs/) | 5판 주문, 클래스, 몬스터 등에 대한 참조 | No | No | No |
+| [Dungeons and Dragons (Alternate)](https://open5e.com/) | SRD(시스템 참조 문서)의 모든 몬스터와 주문 및 검색 API를 포함합니다. | No | Yes | Yes |
+| [Eve Online](https://esi.evetech.net/ui) | 제3자 개발자 문서 | `OAuth` | Yes | Unknown |
+| [FFXIV Collect](https://ffxivcollect.com/) | 수집품에 대한 Final Fantasy XIV 데이터 | No | Yes | Yes |
+| [FIFA Ultimate Team](https://www.easports.com/fifa/ultimate-team/api/fut/item) | FIFA Ultimate Team 아이템 API | No | Yes | Unknown |
+| [Final Fantasy XIV](https://xivapi.com/) | 파이널 판타지 XIV 게임 데이터 API | No | Yes | Yes |
+| [Fortnite](https://fortnitetracker.com/site-api) | 포트나이트 통계 | `apiKey` | Yes | Unknown |
+| [Forza](https://docs.forza-api.tk) | Forza에서 임의의 자동차 이미지 표시 | No | Yes | Unknown |
+| [FreeToGame](https://www.freetogame.com/api-doc) | 무료 게임 데이터베이스 | No | Yes | Yes |
+| [Fun Facts](https://asli-fun-fact-api.herokuapp.com/) | 무작위 재미있는 사실 | No | Yes | Yes |
+| [FunTranslations](https://api.funtranslations.com/) | 텍스트를 재미있는 언어로 번역하세요 | No | Yes | Yes |
+| [GamerPower](https://www.gamerpower.com/api-read) | 게임 경품 추적기 | No | Yes | Yes |
+| [GDBrowser](https://gdbrowser.com/api) | Geometry Dash 서버를 사용하는 쉬운 방법 | No | Yes | Unknown |
+| [Geek-Jokes](https://github.com/sameerkumar18/geek-joke-api) | 모든 종류의 애플리케이션에 사용할 수 있는 임의의 괴짜/프로그래밍 관련 농담을 가져옵니다. | No | Yes | Yes |
+| [Genshin Impact](https://genshin.dev) | Genshin Impact 게임 데이터 | No | Yes | Yes |
+| [Giant Bomb](https://www.giantbomb.com/api/documentation) | 비디오 게임 | `apiKey` | Yes | Unknown |
+| [GraphQL Pokemon](https://github.com/favware/graphql-pokemon) | GraphQL 기반 포켓몬 API. 1~8세대 지원 | No | Yes | Yes |
+| [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main) | 길드워 2 게임 정보 | `apiKey` | Yes | Unknown |
+| [GW2Spidy](https://github.com/rubensayshi/gw2spidy/wiki) | GW2Spidy API, Guild Wars 2 무역 시장의 아이템 데이터 | No | Yes | Unknown |
+| [Halo](https://developer.haloapi.com/) | Halo 5 및 Halo Wars 2 정보 | `apiKey` | Yes | Unknown |
+| [Hearthstone](http://hearthstoneapi.com/) | 하스스톤 카드 정보 | `X-Mashape-Key` | Yes | Unknown |
+| [Humble Bundle](https://rapidapi.com/Ziggoto/api/humble-bundle) | Humble Bundle의 현재 번들 | `apiKey` | Yes | Unknown |
+| [Humor](https://humorapi.com) | 유머, 농담, 밈 | `apiKey` | Yes | Unknown |
+| [Hypixel](https://api.hypixel.net/) | Hypixel 플레이어 통계 | `apiKey` | Yes | Unknown |
+| [Hyrule Compendium](https://github.com/gadhagod/Hyrule-Compendium-API) | The Legend of Zelda: BOTW의 모든 대화형 항목에 대한 데이터 | No | Yes | Unknown |
+| [Hytale](https://hytale-api.com/) | Hytale 블로그 게시물 및 채용 정보 | No | Yes | Unknown |
+| [IGDB.com](https://api-docs.igdb.com) | 비디오 게임 데이터베이스 | `apiKey` | Yes | Unknown |
+| [JokeAPI](https://sv443.net/jokeapi/v2/) | 프로그래밍, 기타 및 다크 유머 | No | Yes | Yes |
+| [Jokes One](https://jokes.one/api/joke/) | 오늘의 농담 및 REST API를 통해 접근 가능한 대규모 농담 카테고리 | `apiKey` | Yes | Yes |
+| [Jservice](http://jservice.io) | 제오파디 질문 데이터베이스 | No | No | Unknown |
+| [Lichess](https://lichess.org/api) | Lichess의 사용자, 게임, 퍼즐 등의 모든 데이터에 접근 | `OAuth` | Yes | Unknown |
+| [Magic The Gathering](http://magicthegathering.io/) | 매직 더 개더링 게임 정보 | No | No | Unknown |
+| [Mario Kart Tour](https://mario-kart-tour-api.herokuapp.com/) | 드라이버, 카트, 글라이더 및 코스용 API | `OAuth` | Yes | Unknown |
+| [Marvel](https://developer.marvel.com) | 마블 코믹스 | `apiKey` | Yes | Unknown |
+| [Minecraft Server Status](https://api.mcsrvstat.us) | Minecraft 서버에 대한 정보를 가져오는 API | No | Yes | No |
+| [MMO Games](https://www.mmobomb.com/api) | MMO 게임 데이터베이스, 뉴스 및 경품 행사 | No | Yes | No |
+| [mod.io](https://docs.mod.io) | 크로스 플랫폼 모드 API | `apiKey` | Yes | Unknown |
+| [Mojang](https://wiki.vg/Mojang_API) | 모장/마인크래프트 API | `apiKey` | Yes | Unknown |
+| [Monster Hunter World](https://docs.mhw-db.com/) | 몬스터헌터 월드 데이터 | No | Yes | Yes |
+| [Open Trivia](https://opentdb.com/api_config.php) | 퀴즈 질문 | No | Yes | Unknown |
+| [PandaScore](https://developers.pandascore.co/) | E-스포츠 경기 및 결과 | `apiKey` | Yes | Unknown |
+| [Path of Exile](https://www.pathofexile.com/developer/docs) | 패스 오브 엑자일 게임 정보 | `OAuth` | Yes | Unknown |
+| [PlayerDB](https://playerdb.co/) | Minecraft, Steam 및 XBox 계정 쿼리 | No | Yes | Unknown |
+| [Pokéapi](https://pokeapi.co) | 포켓몬 정보 | No | Yes | Unknown |
+| [PokéAPI (GraphQL)](https://github.com/mazipan/graphql-pokeapi) | PokeAPI용 비공식 GraphQL | No | Yes | Yes |
+| [Pokémon TCG](https://pokemontcg.io) | 포켓몬 TCG 정보 | No | Yes | Unknown |
+| [Psychonauts](https://psychonauts-api.netlify.app/) | Psychonauts World 캐릭터 정보 및 PSI 능력 | No | Yes | Yes |
+| [PUBG](https://developer.pubg.com/) | 게임 내 PUBG 데이터에 액세스 | `apiKey` | Yes | Yes |
+| [Puyo Nexus](https://github.com/deltadex7/puyodb-api-deno) | Puyo Puyo Wiki의 Puyo Puyo 정보 | No | Yes | Yes |
+| [quizapi.io](https://quizapi.io/) | 다양한 종류의 퀴즈 질문에 접근 | `apiKey` | Yes | Yes |
+| [Raider](https://raider.io/api) | 월드 오브 워크래프트의 공격대 및 신화+ 콘텐츠에 대한 상세한 캐릭터 및 길드 순위를 제공합니다. | No | Yes | Unknown |
+| [RAWG.io](https://rawg.io/apidocs) | 모바일을 포함한 50개 플랫폼을 위한 500,000개 이상의 게임 | `apiKey` | Yes | Unknown |
+| [Rick and Morty](https://rickandmortyapi.com) | 이미지를 포함한 모든 릭 앤 모티 정보 | No | Yes | Yes |
+| [Riot Games](https://developer.riotgames.com/) | 리그 오브 레전드 게임 정보 | `apiKey` | Yes | Unknown |
+| [RPS 101](https://rps101.pythonanywhere.com/api) | 가위바위보 101개 물체 | No | Yes | Yes |
+| [RuneScape](https://runescape.wiki/w/Application_programming_interface) | RuneScape 및 OSRS RPG 정보 | No | Yes | No |
+| [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api) | 사쿠라 CardCaptor 카드 정보 | No | Yes | Unknown |
+| [Scryfall](https://scryfall.com/docs/api) | 매직: 더 개더링 데이터베이스 | No | Yes | Yes |
+| [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | 플레이 가능한 은하계 공간 거래 MMOAPI | `OAuth` | Yes | Yes |
+| [Steam](https://steamapi.xpaw.me/) | Steam 웹 API 문서 | `apiKey` | Yes | No |
+| [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | 내부 Steam 웹 API 문서 | No | Yes | No |
+| [SuperHeroes](https://superheroapi.com) | 단일 API 하에 모든 우주의 모든 슈퍼히어로 및 빌런 데이터 | `apiKey` | Yes | Unknown |
+| [TCGdex](https://www.tcgdex.net/docs) | 다국어 포켓몬 TCG 정보 | No | Yes | Yes |
+| [Tebex](https://docs.tebex.io/plugin/) | 게임 구매에 대한 정보를 제공하는 Tebex API | `X-Mashape-Key` | Yes | No |
+| [TETR.IO](https://tetr.io/about/api/) | TETR.IO 테트라 채널 API | No | Yes | Unknown |
+| [Tronald Dump](https://www.tronalddump.io/) | 도널드 트럼프가 한 말 중 가장 멍청한 말 | No | Yes | Unknown |
+| [Universalis](https://universalis.app/docs/index.html) | Final Fantasy XIV 마켓 보드 데이터 | No | Yes | Yes |
+| [Valorant (non-official)](https://valorant-api.com) | 대부분의 Valorant 게임 내 아이템, 자산 등의 데이터를 포함하는 광범위한 API | No | Yes | Unknown |
+| [Warface (non-official)](https://api.wfstats.cf) | 더 나은 데이터 구조와 더 많은 기능을 갖춘 공식 API 프록시 | No | Yes | No |
+| [Wargaming.net](https://developers.wargaming.net/) | Wargaming.net 정보 및 통계 | `apiKey` | Yes | No |
+| [When is next MCU film](https://github.com/DiljotSG/MCU-Countdown/blob/develop/docs/API.md) | 다가오는 MCU 영화 정보 | No | Yes | Unknown |
+| [xkcd](https://xkcd.com/json.html) | xkcd 만화를 JSON으로 검색 | No | Yes | No |
+| [Yu-Gi-Oh!](https://db.ygoprodeck.com/api-guide/) | 유기오! TCG 정보 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 지오코딩
 
-|                                                          API                                                           | 설명                                                                                           |      인증      | HTTPS |  CORS   |
-| :--------------------------------------------------------------------------------------------------------------------: | ---------------------------------------------------------------------------------------------- | :------------: | :---: | :-----: |
-|              [administrative-divisons-db](https://github.com/kamikazechaser/administrative-divisions-db)               | 국가의 모든 행정 구역 가져오기                                                                 |       No       |  Yes  |   Yes   |
-|                                  [adresse.data.gouv.fr](https://adresse.data.gouv.fr)                                  | 프랑스 주소 데이터베이스, 지오코딩 및 역지오코딩                                               |       No       |  Yes  | Unknown |
-|                                         [Battuta](http://battuta.medunes.net)                                          | 계층적 위치 API (국가/지역/도시)                                                               |    `apiKey`    |  No   | Unknown |
-|                                      [Bing Maps](https://www.microsoft.com/maps/)                                      | Bing Maps 데이터 기반 디지털 지도 생성/사용자화                                                |    `apiKey`    |  Yes  | Unknown |
-|                                 [bng2latlong](https://www.getthedata.com/bng2latlong)                                  | 영국 OSGB36 동쪽 및 북쪽 좌표(영국 국가 격자)를 WGS84 위도 및 경도로 변환                     |       No       |  Yes  |   Yes   |
-|                                   [CitySDK](http://www.citysdk.eu/citysdk-toolkit/)                                    | 선택된 유럽 도시를 위한 공개 API                                                               |       No       |  Yes  | Unknown |
-|                                             [Country](http://country.is/)                                              | 방문자의 IP에서 국가 정보 가져오기                                                             |       No       |  Yes  |   Yes   |
-|                                         [Daum Maps](http://apis.map.daum.net/)                                         | 한국 지도를 위한 다양한 Daum Maps API                                                          |    `apiKey`    |  No   | Unknown |
-|                                          [FreeGeoIP](https://freegeoip.app/)                                           | 무료 지오 IP 정보, 등록 불필요. 시간당 15k 제한                                                |       No       |  Yes  |   Yes   |
-|                                     [GeoApi](https://api.gouv.fr/api/geoapi.html)                                      | 프랑스 지리 데이터                                                                             |       No       |  Yes  | Unknown |
-|                                          [Geocod.io](https://www.geocod.io/)                                           | 대량 주소 지오코딩 / 역지오코딩                                                                |    `apiKey`    |  Yes  | Unknown |
-|                                          [Geocode.xyz](https://geocode.xyz/)                                           | 전 세계 순방향/역방향 지오코딩, 대량 지오코딩 및 지오파싱 제공                                 |       No       |  Yes  | Unknown |
-|                                        [Geocodify.com](https://geocodify.com/)                                         | 엔터프라이즈급 지오코딩 및 지오파싱                                                            |    `apiKey`    |  Yes  |   Yes   |
-|                               [GeoDataSource](https://www.geodatasource.com/web-service)                               | 위도 및 경도 좌표를 사용한 도시명 지오코딩                                                     |    `apiKey`    |  Yes  | Unknown |
-|                                               [GeoJS](https://geojs.io/)                                               | ChatOps 통합이 포함된 IP 지리위치                                                              |       No       |  Yes  |   Yes   |
-|                                             [Geokeo](https://geokeo.com/)                                              | 일일 2500개 무료 제한이 있는 순방향 및 역방향 지오코딩                                         |    `apikey`    |  Yes  |   Yes   |
-|                                        [Geolocated.io](https://geolocated.io/)                                         | 무료 IP 지리위치 API: 일일 2000회 조회, 전 세계 여러 서버                                     |    `apikey`    |  Yes  |   Yes   |
-|                                         [geoPlugin](https://www.geoplugin.com)                                         | IP 지리위치 및 통화 변환                                                                       |       No       |  Yes  |   Yes   |
-|                           [Google Earth Engine](https://developers.google.com/earth-engine/)                           | 행성 규모의 환경 데이터 분석을 위한 클라우드 기반 플랫폼                                       |    `apiKey`    |  Yes  | Unknown |
-|                                   [Google Maps](https://developers.google.com/maps/)                                   | Google Maps 데이터 기반 디지털 지도 생성/사용자화                                              |    `apiKey`    |  Yes  | Unknown |
-|                              [HelloSalut](https://www.fourtonfish.com/hellosalut/hello/)                               | 사용자 언어에 따른 인사말 번역                                                                 |       No       |  Yes  | Unknown |
-|                                        [HERE Maps](https://developer.here.com)                                         | HERE Maps 데이터 기반 디지털 지도 생성/사용자화                                                |    `apiKey`    |  Yes  | Unknown |
-|                             [Indian Cities](https://indian-cities-api-nocbegfhqg.now.sh/)                              | 깔끔한 JSON 형식으로 모든 인도 도시 정보                                                       |       No       |  Yes  |   Yes   |
-|                                        [IP 2 Country](https://ip2country.info)                                         | IP를 국가에 매핑                                                                               |       No       |  Yes  | Unknown |
-|                                        [IP Address Details](https://ipinfo.io/)                                        | IP 주소로 지리위치 찾기                                                                        |       No       |  Yes  | Unknown |
-|                                        [IP (LabStack)](http://labstack.com/ip)                                         | IP의 국가, 지역, 도시, 시간대, 통화 및 언어 조회                                               |    `apiKey`    |  Yes  |   Yes   |
-|                                           [IP Location](http://ip-api.com/)                                            | IP 주소로 위치 찾기                                                                            |       No       |  No   | Unknown |
-|                                            [IP Location](https://ipapi.co/)                                            | IP 주소 위치 정보 찾기                                                                         |       No       |  Yes  | Unknown |
-|                                      [IP Vigilante](https://www.ipvigilante.com/)                                      | 무료 IP 지리위치 API                                                                           |       No       |  Yes  | Unknown |
-|                           [IP2Location](https://www.ip2location.com/web-service/ip2location)                           | 55개 이상 매개변수를 얻는 IP 지리위치 웹 서비스                                                |    `apiKey`    |  Yes  | Unknown |
-|                                      [IP2Location.io](https://www.ip2location.io)                                      | 사용자 위치 정보를 지리위치로 표시하는 무료 IP 지리위치 API                                    |    `apiKey`    |  Yes  |   Yes   |
-|                              [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy)                              | IP 주소를 사용한 프록시 및 VPN 감지                                                            |    `apiKey`    |  Yes  | Unknown |
-|                                 [IPGeolocationAPI.com](https://ipgeolocationapi.com/)                                  | 국가 세부정보로 IP를 통해 방문자 위치 찾기                                                     |       No       |  Yes  |   Yes   |
-|                                          [IPInfoDB](https://ipinfodb.com/api)                                          | IP 주소별 국가, 지역, 도시 및 시간대 조회를 위한 무료 지리위치 도구 및 API                     |    `apiKey`    |  Yes  | Unknown |
-|                                            [ipstack](https://ipstack.com/)                                             | IP 주소로 웹사이트 방문자 위치 찾기 및 식별                                                    |    `apiKey`    |  Yes  | Unknown |
-|                                      [ipgeolocation](https://ipgeolocation.com/)                                       | IP 지리위치 API로 모든 IP 주소의 지리위치 찾기                                                 |    `apiKey`    |  Yes  |   Yes   |
-|                                          [IsItWater](https://IsItWater.com/)                                           | 위도/경도가 물 위인지 육지인지 확인하는 무료 API                                               | `rapidapi-key` |  Yes  |   Yes   |
-|                          [Airtel IP](https://aether.epias.ltd/ip2country/1.1.1.1/?full=true)                           | IP 지리위치 API. 여러 소스에서 데이터 수집                                                     |       No       |  Yes  | Unknown |
-|                                       [LocationIQ](https://locationiq.org/docs/)                                       | 순방향/역방향 지오코딩 및 대량 지오코딩 제공                                                   |    `apiKey`    |  Yes  |   Yes   |
-|                                      [Mapbox](https://www.mapbox.com/developers/)                                      | 아름다운 디지털 지도 생성/사용자화                                                             |    `apiKey`    |  Yes  | Unknown |
-|                                    [Mexico](https://github.com/IcaliaLabs/sepomex)                                     | 멕시코 RESTful 우편번호 API                                                                    |       No       |  Yes  | Unknown |
-|                                     [One Map, Singapore](https://docs.onemap.sg/)                                      | 싱가포르 주소를 위한 싱가포르 토지청 REST API 서비스                                           |    `apiKey`    |  Yes  | Unknown |
-|                                          [OpenCage](https://opencagedata.com)                                          | 공개 데이터를 사용한 순방향 및 역방향 지오코딩                                                 |    `apiKey`    |  Yes  |   Yes   |
-|                                       [OpenPLZ API](https://www.openplzapi.org/)                                       | 공개 REST API를 통한 오스트리아, 독일, 리히텐슈타인, 스위스의 공개 거리 및 우편번호 디렉토리  |       No       |  Yes  |   Yes   |
-|                                [OpenStreetMap](http://wiki.openstreetmap.org/wiki/API)                                 | 내비게이션, 지리위치 및 지리 데이터                                                            |    `OAuth`     |  No   | Unknown |
-| [PostcodeData.nl](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) | 네덜란드 주소의 우편번호 기반 지리위치 데이터 제공                                             |       No       |  No   | Unknown |
-|                                          [Postcodes.io](https://postcodes.io)                                          | 영국의 우편번호 조회 및 지리위치                                                               |       No       |  Yes  |   Yes   |
-|                                      [REST Countries](https://restcountries.com)                                       | RESTful API를 통한 국가 정보                                                                   |       No       |  Yes  |   Yes   |
-|                                            [SmartIP.io](https://smartip.io)                                            | IP 지리위치 및 위협 인텔리전스 API                                                             |    `apiKey`    |  Yes  |   Yes   |
-|                                           [The IP API](https://theipapi.com)                                           | 국가, 지역, 도시 등의 데이터가 포함된 IP to Location API                                       |    `apiKey`    |  Yes  | Unknown |
-|                                       [Uebermaps](https://uebermaps.com/api/v2)                                        | 친구들과 지도 발견 및 공유                                                                     |    `apiKey`    |  Yes  | Unknown |
-|                           [US Zip Codes](https://www.metadapi.com/API-Products/Zip-Code-API)                           | 미국 우편번호의 완전한 데이터, 거리, 반경 및 통계                                              |    `apiKey`    |  Yes  | Unknown |
-|                           [US ZipCode](https://smartystreets.com/docs/cloud/us-zipcode-api)                            | 모든 미국 우편번호 검증 및 데이터 추가                                                         |    `apiKey`    |  Yes  |   Yes   |
-|                                            [ViaCep](https://viacep.com.br)                                             | 브라질 RESTful 우편번호 API                                                                    |       No       |  Yes  | Unknown |
-|                                        [ZipCodeAPI](https://www.zipcodeapi.com)                                        | 미국 우편번호 거리, 반경 및 위치 API                                                           |    `apiKey`    |  Yes  | Unknown |
-|                                         [Zippopotam](http://www.zippopotam.us)                                         | 국가, 도시, 주 등의 장소에 대한 정보                                                           |       No       |  No   | Unknown |
-|                                         [Ziptastic](https://ziptasticapi.com/)                                         | 모든 미국 우편번호의 국가, 주, 도시 정보                                                       |       No       |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [IPstack](https://ipstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | IP 주소로 웹사이트 방문자를 찾아 식별합니다. | `apiKey` | Yes | Unknown |
+| [ipapi.com](https://ipapi.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 실시간 위치정보 및 역방향 IP 조회 REST API | `apiKey` | Yes | Unknown |
+| [Actinia Grass GIS](https://actinia.mundialis.de/api_docs/) | Actinia는 GRASS GIS를 사용하는 지리 데이터용 오픈 소스 REST API. | `apiKey` | Yes | Unknown |
+| [administrative-divisons-db](https://github.com/kamikazechaser/administrative-divisions-db) | 국가의 모든 행정 구역 가져오기 | No | Yes | Yes |
+| [ApogeoAPI](https://apogeoapi.com) | 국가, 주, 도시, IP 위치정보 및 실시간 환율을 위한 번들 API | `apiKey` | Yes | Yes |
+| [adresse.data.gouv.fr](https://adresse.data.gouv.fr) | 프랑스 주소 데이터베이스, 지오코딩 및 역지오코딩 | No | Yes | Unknown |
+| [Airtel IP](https://sys.airtel.lv/ip2country/1.1.1.1/?full=true) | IP 위치정보 API. 여러 소스에서 데이터 수집 | No | Yes | Unknown |
+| [Apiip](https://apiip.net/) | IP 주소로 위치 정보 얻기 | `apiKey` | Yes | Yes |
+| [Battuta](http://battuta.medunes.net) | 계층적 위치 API (국가/지역/도시) | `apiKey` | No | Unknown |
+| [BdAPIs](https://bdapis.com/) | 방글라데시의 부서, 구역, 우파질라를 가져옵니다. | No | Yes | Unknown |
+| [BigDataCloud](https://www.bigdatacloud.com/ip-geolocation-apis) | 보안 검사 및 신뢰 영역과 함께 빠르고 정확한 IP 위치정보 API를 제공합니다. | `apiKey` | Yes | Unknown |
+| [Bing Maps](https://www.microsoft.com/maps/) | Bing Maps 데이터 기반 디지털 지도 생성/사용자화 | `apiKey` | Yes | Unknown |
+| [bng2latlong](https://www.getthedata.com/bng2latlong) | 영국 OSGB36 동쪽 및 북쪽 좌표(영국 국가 격자)를 WGS84 위도 및 경도로 변환 | No | Yes | Yes |
+| [Cartes.io](https://github.com/M-Media-Group/Cartes.io/wiki/API) | 무엇이든 지도와 마커를 만드세요 | No | Yes | Unknown |
+| [Cep.la](http://cep.la/) | 거리, 우편번호, 인근 지역, 도시 및 주에 대한 정보를 찾는 브라질 RESTful API | No | No | Unknown |
+| [CitySDK](http://www.citysdk.eu/citysdk-toolkit/) | 선택된 유럽 도시를 위한 공개 API | No | Yes | Unknown |
+| [Country](http://country.is/) | 방문자의 IP에서 국가 정보 가져오기 | No | Yes | Yes |
+| [CountryStateCity](https://countrystatecity.in/) | JSON, SQL, XML, YAML 및 CSV 형식의 세계 국가, 주, 지역, 지방, 도시 및 마을 | `apiKey` | Yes | Yes |
+| [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api) | 위치 및 도시에 대한 JSON 응답이 포함된 쿼리 URL을 제공하는 API 탐색기 | No | Yes | No |
+| [GeoApi](https://api.gouv.fr/api/geoapi.html) | 프랑스 지리 데이터 | No | Yes | Unknown |
+| [Geoapify](https://www.geoapify.com/api/geocoding-api/) | 정방향 및 역방향 지오코딩, 주소 자동 완성 | `apiKey` | Yes | Yes |
+| [Geocod.io](https://www.geocod.io/) | 대량 주소 지오코딩 / 역지오코딩 | `apiKey` | Yes | Unknown |
+| [Geocode.xyz](https://geocode.xyz/api) | 전 세계적으로 정방향/역방향 지오코딩, 일괄 지오코딩 및 지오파싱을 제공합니다. | No | Yes | Unknown |
+| [Geocodify.com](https://geocodify.com/) | 엔터프라이즈급 지오코딩 및 지오파싱 | `apiKey` | Yes | Yes |
+| [Geodata.gov.gr](https://geodata.gov.gr/en/) | 그리스를 위한 개방형 지리공간 데이터 및 API 서비스 | No | Yes | Unknown |
+| [GeoDataSource](https://www.geodatasource.com/web-service) | 위도 및 경도 좌표를 사용한 도시명 지오코딩 | `apiKey` | Yes | Unknown |
+| [GeoDB Cities](http://geodb-cities-api.wirefreethought.com/) | 전 세계 도시, 지역, 국가 데이터 가져오기 | `apiKey` | Yes | Unknown |
+| [GeographQL](https://geographql.netlify.app) | 국가, 주, 도시 GraphQL API | No | Yes | Yes |
+| [GeoJS](https://www.geojs.io/) | ChatOps 통합을 통한 IP 위치정보 | No | Yes | Yes |
+| [Geokeo](https://geokeo.com) | Geokeo 지오코딩 서비스 - 매일 2500개의 무료 API 요청 제공 | No | Yes | Yes |
+| [GeoNames](http://www.geonames.org/export/web-services.html) | 지명 및 기타 지리적 데이터 | No | No | Unknown |
+| [geoPlugin](https://www.geoplugin.com) | IP 지리위치 및 통화 변환 | No | Yes | Yes |
+| [Google Earth Engine](https://developers.google.com/earth-engine/) | 행성 규모의 환경 데이터 분석을 위한 클라우드 기반 플랫폼 | `apiKey` | Yes | Unknown |
+| [Google Maps](https://developers.google.com/maps/) | Google Maps 데이터 기반 디지털 지도 생성/사용자화 | `apiKey` | Yes | Unknown |
+| [Graph Countries](https://github.com/lennertVanSever/graphcountries) | 통화, 언어, 국기, 지역+소지역, 국경 국가 등 국가 관련 데이터 | No | Yes | Unknown |
+| [HelloSalut](https://fourtonfish.com/project/hellosalut-api/) | 사용자 언어에 따라 Hello 번역 받기 | No | Yes | Unknown |
+| [HERE Maps](https://developer.here.com) | HERE Maps 데이터 기반 디지털 지도 생성/사용자화 | `apiKey` | Yes | Unknown |
+| [Hirak IP to Country](https://iplocation.hirak.site/) | 국가 코드, 통화 코드 및 통화 이름이 포함된 위치로 IP 이동, 빠른 응답, 무제한 요청 | `apiKey` | Yes | Unknown |
+| [Hong Kong GeoData Store](https://geodata.gov.hk/gs/) | 홍콩의 지리 데이터에 접근하기 위한 API | No | Yes | Unknown |
+| [IBGE](https://servicodados.ibge.gov.br/api/docs/) | IBGE(브라질 지리통계연구소)의 종합 서비스 | No | Yes | Unknown |
+| [IP 2 Country](https://ip2country.info) | IP를 국가에 매핑 | No | Yes | Unknown |
+| [IP Address Details](https://ipinfo.io/) | IP 주소로 지리위치 찾기 | No | Yes | Unknown |
+| [IP Vigilante](https://www.ipvigilante.com/) | 무료 IP 지리위치 API | No | Yes | Unknown |
+| [ip-api](https://ip-api.com/docs) | IP 주소 또는 도메인으로 위치 찾기 | No | No | Unknown |
+| [IP Geolocation](https://www.abstractapi.com/ip-geolocation-api) | IP를 통해 웹사이트 방문자의 위치를 ​​파악하세요 | `apiKey` | Yes | Yes |
+| [IP2Location](https://www.ip2location.com/web-service/ip2location) | 55개 이상 매개변수를 얻는 IP 지리위치 웹 서비스 | `apiKey` | Yes | Unknown |
+| [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy) | IP 주소를 사용한 프록시 및 VPN 감지 | `apiKey` | Yes | Unknown |
+| [ipapi.co](https://ipapi.co/api/#introduction) | IP 주소 위치 정보 찾기 | No | Yes | Yes |
+| [IPGEO](https://api.techniknews.net/ipgeo/) | 유용한 정보가 포함된 무제한 무료 IP 주소 API | No | Yes | Unknown |
+| [ipgeolocation](https://ipgeolocation.io/) | 매월 30,000개의 요청을 무료로 제공하는 IP Geolocation AP | `apiKey` | Yes | Yes |
+| [IPInfoDB](https://www.ipinfodb.com/api) | IP 주소로 국가, 지역, 도시 및 시간대 조회를 위한 무료 위치정보 도구 및 API | `apiKey` | Yes | Unknown |
+| [ipstack](https://ipstack.com/) | IP 주소로 웹사이트 방문자 위치 찾기 및 식별 | `apiKey` | Yes | Unknown |
+| [Kakao Maps](https://apis.map.kakao.com) | 카카오맵은 다양한 한국 지도 API를 제공합니다. | `apiKey` | Yes | Unknown |
+| [keycdn IP Location Finder](https://tools.keycdn.com/geo) | 간단한 REST API를 통해 IP 지리적 위치 데이터를 가져옵니다. 모든 응답은 JSON으로 인코딩됩니다. | `apiKey` | Yes | Unknown |
+| [LocationIQ](https://locationiq.org/docs/) | 순방향/역방향 지오코딩 및 대량 지오코딩 제공 | `apiKey` | Yes | Yes |
+| [Longdo Map](https://map.longdo.com/docs/) | 태국의 상세한 장소와 정보 포털이 포함된 대화형 지도 | `apiKey` | Yes | Yes |
+| [Mapbox](https://docs.mapbox.com/) | 아름다운 디지털 지도 생성/맞춤화 | `apiKey` | Yes | Unknown |
+| [MapQuest](https://developer.mapquest.com/) | 세계 지도 작성을 위한 도구 및 리소스에 액세스하려면 | `apiKey` | Yes | No |
+| [Mexico](https://github.com/IcaliaLabs/sepomex) | 멕시코 RESTful 우편번호 API | No | Yes | Unknown |
+| [Nominatim](https://nominatim.org/release-docs/latest/api/Overview/) | 전세계 정방향/역방향 지오코딩 제공 | No | Yes | Yes |
+| [One Map, Singapore](https://www.onemap.gov.sg/docs/) | 싱가포르 주소에 대한 싱가포르 토지청 REST API 서비스 | `apiKey` | Yes | Unknown |
+| [OnWater](https://onwater.io/) | 위도/경도가 물 위에 있는지 육지 위에 있는지 확인 | No | Yes | Unknown |
+| [Open Topo Data](https://www.opentopodata.org) | 위도와 경도에 대한 고도와 해양 깊이 | No | Yes | No |
+| [OpenCage](https://opencagedata.com) | 공개 데이터를 사용한 순방향 및 역방향 지오코딩 | `apiKey` | Yes | Yes |
+| [openrouteservice.org](https://openrouteservice.org/) | 방향, POI, 등시선, 지오코딩(+역방향), 고도 등 | `apiKey` | Yes | Unknown |
+| [OpenStreetMap](http://wiki.openstreetmap.org/wiki/API) | 내비게이션, 지리위치 및 지리 데이터 | `OAuth` | No | Unknown |
+| [Pinball Map](https://pinballmap.com/api/v1/docs) | 공공 핀볼 기계의 크라우드소싱 지도 | No | Yes | Yes |
+| [positionstack](https://positionstack.com/) | 정방향 및 역방향 일괄 지오코딩 REST API | `apiKey` | Yes | Unknown |
+| [Postali](https://postali.app/api) | 멕시코 우편 번호 API | No | Yes | Yes |
+| [PostcodeData.nl](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) | 네덜란드 주소의 우편번호 기반 지리위치 데이터 제공 | No | No | Unknown |
+| [Postcodes.io](https://postcodes.io) | 영국의 우편번호 조회 및 지리위치 | No | Yes | Yes |
+| [PostalCodes](https://postalcodes.info/api) | 우편번호 검색, 국가 수출, 주소 검증 데이터 | No | Yes | Unknown |
+| [Queimadas INPE](https://queimadas.dgi.inpe.br/queimadas/dados-abertos/) | 열 집중 데이터에 대한 액세스(산불 가능성) | No | Yes | Unknown |
+| [REST Countries](https://restcountries.com) | RESTful API를 통한 국가 정보 | No | Yes | Yes |
+| [RoadGoat Cities](https://www.roadgoat.com/business/cities-api) | 도시 콘텐츠 및 사진 API | `apiKey` | Yes | No |
+| [Rwanda Locations](https://rapidapi.com/victorkarangwa4/api/rwanda) | 르완다 프로방스, 지구, 도시, 수도, 부문, 셀, 마을 및 거리 | No | Yes | Unknown |
+| [SLF](https://github.com/slftool/slftool.github.io/blob/master/API.md) | 독일 도시, 국가, 강, 데이터베이스 | No | Yes | Yes |
+| [SpotSense](https://spotsense.io/) | 모바일 앱에 위치 기반 상호 작용 추가 | `apiKey` | Yes | Unknown |
+| [Telize](https://rapidapi.com/fcambus/api/telize/) | Telize는 모든 IP 주소에서 위치 정보를 제공합니다. | `apiKey` | Yes | Yes |
+| [TomTom](https://developer.tomtom.com/) | 지도, 길찾기, 장소 및 교통 API | `apiKey` | Yes | Yes |
+| [Uebermaps](https://uebermaps.com/api/v2) | 친구들과 지도 발견 및 공유 | `apiKey` | Yes | Unknown |
+| [US ZipCode](https://www.smarty.com/docs/cloud/us-zipcode-api) | 모든 미국 우편번호에 대한 데이터 검증 및 추가 | `apiKey` | Yes | Yes |
+| [Utah AGRC](https://api.mapserv.utah.gov) | 유타 주소를 지오코딩하기 위한 유타 웹 API | `apiKey` | Yes | Unknown |
+| [ViaCep](https://viacep.com.br) | 브라질 RESTful 우편번호 API | No | Yes | Unknown |
+| [What3Words](https://what3words.com) | 전 세계적으로 기억에 남는 독특한 좌표 세 단어 | `apiKey` | Yes | Unknown |
+| [Yandex.Maps Geocoder](https://yandex.com/dev/maps/geocoder) | 지오코딩을 사용하여 주소에서 개체의 좌표를 가져옵니다. | `apiKey` | Yes | Unknown |
+| [ZipCodeAPI](https://www.zipcodeapi.com) | 미국 우편번호 거리, 반경 및 위치 API | `apiKey` | Yes | Unknown |
+| [Zippopotam.us](http://www.zippopotam.us) | 국가, 도시, 주 등의 장소에 대한 정보 | No | No | Unknown |
+| [Ziptastic](https://ziptasticapi.com/) | 모든 미국 우편번호의 국가, 주, 도시 정보 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 정부
 
-|                                         API                                         | 설명                                                                         |   인증   | HTTPS |  CORS   |
-| :---------------------------------------------------------------------------------: | ---------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                    [Autobahn API](https://autobahn.api.bund.dev)                    | 공사 현장 및 교통 체증과 같은 독일 연방 고속도로 정보                        |    No    |  Yes  | Unknown |
-|        [BCLaws](http://www.bclaws.ca/civix/template/complete/api/index.html)        | 브리티시컬럼비아 법률 액세스                                                 |    No    |  No   | Unknown |
-|                  [BusinessUSA](https://business.usa.gov/developer)                  | 미국 프로그램, 이벤트, 서비스 등에 대한 권위 있는 정보                       | `apiKey` |  Yes  | Unknown |
-|         [Census.gov](https://www.census.gov/data/developers/data-sets.html)         | 미국 인구조사국에서 인구통계 및 비즈니스에 대한 다양한 API 및 데이터셋 제공  |    No    |  Yes  | Unknown |
-|                  [City, Analyze Boston](https://data.boston.gov/)                   | 보스턴(미국) 시 공개 데이터                                                  | `apiKey` |  Yes  | Unknown |
-|          [City, Lyon Opendata](https://data.beta.grandlyon.com/fr/accueil)          | 리옹(프랑스) 시 공개 데이터                                                  | `apiKey` |  Yes  | Unknown |
-|              [City, Bologna Opendata](https://dati.comune.bologna.it)               | 볼로냐(이탈리아) 시 공개 데이터                                              |    No    |  Yes  | Unknown |
-|        [City, Nantes Opendata](https://data.nantesmetropole.fr/pages/home/)         | 낭트(프랑스) 시 공개 데이터                                                  | `apiKey` |  Yes  | Unknown |
-|         [City, New York City Opendata](https://opendata.cityofnewyork.us/)          | 뉴욕시(미국) 공개 데이터                                                     | `OAuth`  |  Yes  | Unknown |
-|                [City, Prague Opendata](http://opendata.praha.eu/en)                 | 프라하(체코) 시 공개 데이터                                                  |    No    |  No   | Unknown |
-|                            [Code.gov](https://code.gov)                             | 미국 연방 정부의 오픈 소스 및 코드 공유를 위한 주요 플랫폼                   | `apiKey` |  Yes  | Unknown |
-|                  [Colorado Data Engine](http://codataengine.org/)                   | 형식화되고 지리위치가 표시된 콜로라도 공공 데이터                            |    No    |  Yes  | Unknown |
-|           [Colorado Information Marketplace](https://data.colorado.gov/)            | 콜로라도 주 정부 공개 데이터                                                 |    No    |  Yes  | Unknown |
-|                      [Data USA](https://datausa.io/about/api/)                      | 미국 공공 데이터                                                             |    No    |  Yes  | Unknown |
-|                          [Data.gov](https://api.data.gov/)                          | 미국 정부 데이터                                                             | `apiKey` |  Yes  | Unknown |
-|       [Deutscher Bundestag DIP](https://dip.bundestag.de/über-dip/hilfe/api)        | 독일 연방의회 DIP 개체(예: 활동, 인물, 인쇄물) 액세스                        | `apiKey` |  Yes  | Unknown |
-|      [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis)      | 범죄, GIS, 금융 데이터 등을 포함한 D.C. 정부 공공 데이터셋                  |    No    |  Yes  | Unknown |
-|                   [EPA](https://developer.epa.gov/category/apis/)                   | 미국 환경보호청의 웹 서비스 및 데이터셋                                      |    No    |  Yes  | Unknown |
-|                     [FEC](https://api.open.fec.gov/developers/)                     | 연방 선거의 캠페인 기부금 정보                                               | `apiKey` |  Yes  | Unknown |
-| [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources) | 미국 정부의 일간지                                                           |    No    |  Yes  | Unknown |
-|         [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB)         | 영국 식품 위생 등급 데이터 API                                               |    No    |  No   | Unknown |
-|               [Open Government, Australia](https://www.data.gov.au/)                | 호주 정부 공개 데이터                                                        |    No    |  Yes  | Unknown |
-|                  [Open Government, Belgium](https://data.gov.be/)                   | 벨기에 정부 공개 데이터                                                      |    No    |  Yes  | Unknown |
-|                 [Open Government, Canada](http://open.canada.ca/en)                 | 캐나다 정부 공개 데이터                                                      |    No    |  No   | Unknown |
-|                [Open Government, France](https://www.data.gouv.fr/)                 | 프랑스 정부 공개 데이터                                                      | `apiKey` |  Yes  | Unknown |
-|                   [Open Government, India](https://data.gov.in/)                    | 인도 정부 공개 데이터                                                        | `apiKey` |  Yes  | Unknown |
-|                 [Open Government, Italy](https://www.dati.gov.it/)                  | 이탈리아 정부 공개 데이터                                                    |    No    |  Yes  | Unknown |
-|              [Open Government, New Zealand](https://www.data.govt.nz/)              | 뉴질랜드 정부 공개 데이터                                                    |    No    |  Yes  | Unknown |
-|                  [Open Government, Poland](https://dane.gov.pl/en)                  | 폴란드 정부 공개 데이터                                                      |    No    |  Yes  | Unknown |
-|                   [Open Government, Romania](http://data.gov.ro/)                   | 루마니아 정부 공개 데이터                                                    |    No    |  No   | Unknown |
-|                   [Open Government, Taiwan](https://data.gov.tw/)                   | 대만 정부 공개 데이터                                                        |    No    |  Yes  | Unknown |
-|                    [Open Government, USA](https://www.data.gov/)                    | 미국 정부 공개 데이터                                                        |    No    |  Yes  | Unknown |
-|             [Represent by Open North](https://represent.opennorth.ca/)              | 캐나다 정부 대표 찾기                                                        |    No    |  Yes  | Unknown |
-|               [State, New York State Opendata](https://data.ny.gov/)                | 뉴욕주 공개 데이터                                                           | `OAuth`  |  Yes  | Unknown |
-|                   [USAspending.gov](https://api.usaspending.gov/)                   | 미국 연방 지출 데이터                                                        |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | 말레이시아 중앙은행 공개 데이터 | No | Yes | Unknown |
+| [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | 브리티시 컬럼비아 법률 이용 | No | No | Unknown |
+| [Brazil](https://brasilapi.com.br/) | 브라질 공공 데이터를 위한 커뮤니티 중심 API | No | Yes | Yes |
+| [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | 브라질 중앙은행 오픈 데이터 | No | Yes | Unknown |
+| [Brazil Receita WS](https://www.receitaws.com.br/) | 브라질 기업을 위해 CNPJ가 기업에 컨설팅 | No | Yes | Unknown |
+| [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Apis XML, JSON, 다양한 형식의 파일로 입법정보를 제공합니다. | No | Yes | No |
+| [CPFHub](https://cpfhub.io) | 브라질 CPF 조회 — 모든 CPF에 대한 이름, 생년월일 및 성별을 반환합니다. | `apiKey` | Yes | Yes |
+| [Census.gov](https://www.census.gov/data/developers/data-sets.html) | 미국 인구조사국에서 인구통계 및 비즈니스에 대한 다양한 API 및 데이터셋 제공 | No | Yes | Unknown |
+| [City, Berlin](https://daten.berlin.de/) | 베를린(DE) 도시 오픈 데이터 | No | Yes | Unknown |
+| [City, Gdańsk](https://ckan.multimediagdansk.pl/en) | 그단스크(PL) 도시 오픈 데이터 | No | Yes | Unknown |
+| [City, Gdynia](http://otwartedane.gdynia.pl/en/api_doc.html) | 그디니아(PL) 도시 오픈 데이터 | No | No | Unknown |
+| [City, Helsinki](https://hri.fi/en_gb/) | 헬싱키(FI) 도시 오픈 데이터 | No | Yes | Unknown |
+| [City, Lviv](https://opendata.city-adm.lviv.ua/) | Lviv(UA) 시티 오픈 데이터 | No | Yes | Unknown |
+| [City, Nantes Open Data](https://data.nantesmetropole.fr/pages/home/) | 낭트(프랑스) 시 공개 데이터 | `apiKey` | Yes | Unknown |
+| [City, New York Open Data](https://opendata.cityofnewyork.us/) | 뉴욕시(미국) 공개 데이터 | No | Yes | Unknown |
+| [City, Prague Open Data](http://opendata.praha.eu/en) | 프라하(체코) 시 공개 데이터 | No | No | Unknown |
+| [City, Toronto Open Data](https://open.toronto.ca/) | 토론토(CA) 시티 오픈 데이터 | No | Yes | Yes |
+| [Code.gov](https://code.gov) | 미국 연방 정부의 오픈 소스 및 코드 공유를 위한 주요 플랫폼 | `apiKey` | Yes | Unknown |
+| [Colorado Information Marketplace](https://data.colorado.gov/) | 콜로라도 주 정부 공개 데이터 | No | Yes | Unknown |
+| [Data USA](https://datausa.io/about/api/) | 미국 공공 데이터 | No | Yes | Unknown |
+| [Data.gov](https://api.data.gov/) | 미국 정부 데이터 | `apiKey` | Yes | Unknown |
+| [Data.parliament.uk](https://explore.data.parliament.uk/?learnmore=Members) | 청원서, 청구서, 국회의원 투표, 출석 등에 대한 정보를 포함한 실시간 데이터 세트가 포함되어 있습니다. | No | No | Unknown |
+| [Deutscher Bundestag DIP](https://dip.bundestag.de/documents/informationsblatt_zur_dip_api_v01.pdf) | 이 API는 DIP 엔터티(예: 활동, 사람, 인쇄물)에 대한 읽기 액세스를 제공합니다. | `apiKey` | Yes | Unknown |
+| [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis) | 범죄, GIS, 금융 데이터 등을 포함한 D.C. 정부 공공 데이터셋 | No | Yes | Unknown |
+| [EPA](https://www.epa.gov/developers/data-data-products#apis) | 미국 환경 보호국의 웹 서비스 및 데이터 세트 | No | Yes | Unknown |
+| [FBI Wanted](https://www.fbi.gov/wanted/api) | FBI 수배 프로그램 정보에 액세스 | No | Yes | Unknown |
+| [FEC](https://api.open.fec.gov/developers/) | 연방 선거의 캠페인 기부금 정보 | `apiKey` | Yes | Unknown |
+| [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api) | 미국 정부의 일간지 | No | Yes | Unknown |
+| [Food Standards Agency](http://ratings.food.gov.uk/open-data/en-GB) | 영국 식품 위생 등급 데이터 API | No | No | Unknown |
+| [Gazette Data, UK](https://www.thegazette.co.uk/data) | 영국 공식 공공 기록 API | `OAuth` | Yes | Unknown |
+| [Gun Policy](https://www.gunpolicy.org/api) | 국제 총기 부상 예방 및 정책 | `apiKey` | Yes | Unknown |
+| [Indian Pincode](https://indianpincode.com/) | GPS 좌표, 165,000개 이상의 우체국, 주 및 지역 데이터를 사용한 무료 인도 PIN 코드 조회 | No | Yes | Yes |
+| [INEI](http://iinei.inei.gob.pe/microdatos/) | 페루 통계 정부 오픈 데이터 | No | No | Unknown |
+| [Interpol Red Notices](https://interpol.api.bund.dev/) | 인터폴 레드 공지사항 액세스 및 검색 | No | Yes | Unknown |
+| [Istanbul (İBB) Open Data](https://data.ibb.gov.tr) | İstanbul Metropolitan Municipality(İBB)의 데이터 세트 | No | Yes | Unknown |
+| [LocalGov.jp](https://localgov.jp/) | 일본 보조금 및 보조금(중앙 J-Grants + 1,916개 지자체) | No | Yes | Yes |
+| [National Park Service, US](https://www.nps.gov/subjects/developer/) | 미국 국립공원관리청의 데이터 | `apiKey` | Yes | Yes |
+| [Open Government, ACT](https://www.data.act.gov.au/) | 호주 수도 특별구 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Argentina](https://datos.gob.ar/) | 아르헨티나 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Australia](https://www.data.gov.au/) | 호주 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Austria](https://www.data.gv.at/) | 오스트리아 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Belgium](https://data.gov.be/) | 벨기에 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Canada](http://open.canada.ca/en) | 캐나다 정부 공개 데이터 | No | No | Unknown |
+| [Open Government, Colombia](https://www.dane.gov.co/) | 콜롬비아 정부 오픈 데이터 | No | No | Unknown |
+| [Open Government, Cyprus](https://data.gov.cy/?language=en) | 키프로스 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Czech Republic](https://data.gov.cz/english/) | 체코 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Denmark](https://www.opendata.dk/) | 덴마크 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Estonia](https://avaandmed.eesti.ee/instructions/opendata-dataset-api) | 에스토니아 정부 오픈 데이터 | `apiKey` | Yes | Unknown |
+| [Open Government, Finland](https://www.avoindata.fi/en) | 핀란드 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, France](https://www.data.gouv.fr/) | 프랑스 정부 공개 데이터 | `apiKey` | Yes | Unknown |
+| [Open Government, Germany](https://www.govdata.de/daten/-/details/govdata-metadatenkatalog) | 독일 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Greece](https://data.gov.gr/) | 그리스 정부 오픈 데이터 | `OAuth` | Yes | Unknown |
+| [Open Government, India](https://data.gov.in/) | 인도 정부 공개 데이터 | `apiKey` | Yes | Unknown |
+| [Open Government, Ireland](https://data.gov.ie/pages/developers) | 아일랜드 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Italy](https://www.dati.gov.it/) | 이탈리아 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Korea](https://www.data.go.kr/) | 한국 정부 오픈 데이터 | `apiKey` | Yes | Unknown |
+| [Open Government, Lithuania](https://data.gov.lt/public/api/1) | 리투아니아 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Luxembourg](https://data.public.lu) | 룩셈부르크 정부 오픈 데이터 | `apiKey` | Yes | Unknown |
+| [Open Government, Mexico](https://www.inegi.org.mx/datos/) | 멕시코 통계 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Mexico](https://datos.gob.mx/) | 멕시코 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Netherlands](https://data.overheid.nl/en/ondersteuning/data-publiceren/api) | 네덜란드 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, New South Wales](https://api.nsw.gov.au/) | 뉴사우스웨일스 정부 오픈 데이터 | `apiKey` | Yes | Unknown |
+| [Open Government, New Zealand](https://www.data.govt.nz/) | 뉴질랜드 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Norway](https://data.norge.no/dataservices) | 노르웨이 정부 오픈 데이터 | No | Yes | Yes |
+| [Open Government, Peru](https://www.datosabiertos.gob.pe/) | 페루 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Poland](https://dane.gov.pl/en) | 폴란드 정부 공개 데이터 | No | Yes | Yes |
+| [Open Government, Portugal](https://dados.gov.pt/en/docapi/) | 포르투갈 정부 오픈 데이터 | No | Yes | Yes |
+| [Open Government, Queensland Government](https://www.data.qld.gov.au/) | 퀸즈랜드 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Romania](http://data.gov.ro/) | 루마니아 정부 공개 데이터 | No | No | Unknown |
+| [Open Government, Saudi Arabia](https://data.gov.sa) | 사우디아라비아 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Singapore](https://data.gov.sg/developer) | 싱가포르 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Slovakia](https://data.gov.sk/en/) | 슬로바키아 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Slovenia](https://podatki.gov.si/) | 슬로베니아 정부 오픈 데이터 | No | Yes | No |
+| [Open Government, South Australian Government](https://data.sa.gov.au/) | 남호주 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Spain](https://datos.gob.es/en) | 스페인 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Sweden](https://www.dataportal.se/en/dataservice/91_29789/api-for-the-statistical-database) | 스웨덴 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Switzerland](https://handbook.opendata.swiss/de/content/nutzen/api-nutzen.html) | 스위스 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, Taiwan](https://data.gov.tw/) | 대만 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Thailand](https://data.go.th/) | 태국 정부 오픈 데이터 | `apiKey` | Yes | Unknown |
+| [Open Government, UK](https://data.gov.uk/) | 영국 정부 오픈 데이터 | No | Yes | Unknown |
+| [Open Government, USA](https://www.data.gov/) | 미국 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, Victoria State Government](https://www.data.vic.gov.au/) | 빅토리아 주 정부 공개 데이터 | No | Yes | Unknown |
+| [Open Government, West Australia](https://data.wa.gov.au/) | 서호주 오픈 데이터 | No | Yes | Unknown |
+| [OpenRegistry](https://openregistry.sophymarine.com) | 27개 국가 회사 등록부에 대한 실시간 쿼리(UK, FR, DE, IT, ES, KR + 21개 이상) | `OAuth` | Yes | Unknown |
+| [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | 비공식 필리핀 전문 규제 위원회의 시험 일정 | No | Yes | Yes |
+| [Represent by Open North](https://represent.opennorth.ca/) | 캐나다 정부 대표 찾기 | No | Yes | Unknown |
+| [UK Companies House](https://developer.company-information.service.gov.uk/) | 영국 정부의 영국 회사 하우스 데이터 | `OAuth` | Yes | Unknown |
+| [US Presidential Election Data by TogaTech](https://uselection.togatech.org/api/) | 미국 대통령 선거의 상위 2개 정당에 대한 기본 후보 데이터 및 실시간 선거인단 투표 수 | No | Yes | No |
+| [USA.gov](https://www.usa.gov/developer) | 미국 프로그램, 이벤트, 서비스 등에 대한 권위 있는 정보 | `apiKey` | Yes | Unknown |
+| [USAspending.gov](https://api.usaspending.gov/) | 미국 연방 지출 데이터 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 건강
 
-|                                      API                                      | 설명                                                                       |   인증   | HTTPS |  CORS   |
-| :---------------------------------------------------------------------------: | -------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                    [Diabetes](http://predictbgl.com/api/)                     | 당뇨병 정보 로깅 및 검색                                                   |    No    |  No   | Unknown |
-|                     [Flutrack](http://www.flutrack.org/)                      | 지리적 추적을 통한 인플루엔자 유사 증상                                    |    No    |  No   | Unknown |
-|           [Healthcare.gov](https://www.healthcare.gov/developers/)            | 미국 건강보험 마켓플레이스에 대한 교육 콘텐츠                              |    No    |  Yes  | Unknown |
-| [ICD-10 Codes](https://clinicaltables.nlm.nih.gov/apidoc/icd10cm/v3/doc.html) | 모든 의료 진단 코드 목록                                                   |    No    |  Yes  | Unknown |
-|                [Lexigram](https://docs.lexigram.io/v1/welcome)                | 텍스트에서 임상 개념 언급을 추출하는 NLP, 임상 온톨로지 액세스 제공        | `apiKey` |  Yes  | Unknown |
-|                  [Makeup](http://makeup-api.herokuapp.com/)                   | 화장품 정보                                                                |    No    |  No   | Unknown |
-|               [Medicare](https://data.medicare.gov/developers)                | CMS - medicare.gov의 데이터 액세스                                         |    No    |  Yes  | Unknown |
-|          [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api)           | 미국에 등록된 의료 제공자 정보에 대한 국가 계획 및 제공자 열거 시스템       |    No    |  Yes  | Unknown |
-|               [Nutritionix](https://developer.nutritionix.com/)               | 세계 최대 검증된 영양 데이터베이스                                         | `apiKey` |  Yes  | Unknown |
-|                        [openFDA](https://open.fda.gov)                        | 의약품, 의료기기 및 식품에 대한 공개 FDA 데이터                            |    No    |  Yes  | Unknown |
-|           [USDA Nutrients](https://ndb.nal.usda.gov/ndb/doc/index)            | 표준 참조를 위한 국가 영양소 데이터베이스                                  |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [CMS.gov](https://data.cms.gov/provider-data/) | CMS의 데이터에 액세스 - medicare.gov | `apiKey` | Yes | Unknown |
+| [Coronavirus](https://pipedream.com/@pravin/http-api-for-latest-wuhan-coronavirus-data-2019-ncov-p_G6CLVM/readme) | 최신 코로나19 데이터를 위한 HTTP API | No | Yes | Unknown |
+| [Coronavirus in the UK](https://coronavirus.data.gov.uk/details/developers-guide) | 지역별 사망자 및 사례를 포함한 영국 정부 코로나바이러스 데이터 | No | Yes | Unknown |
+| [Covid Tracking Project](https://covidtracking.com/data/api/version-2) | 미국의 코로나19 데이터 | No | Yes | No |
+| [Covid-19](https://covid19api.com/) | 코로나19 확산, 감염 및 회복 | No | Yes | Yes |
+| [Covid-19](https://github.com/M-Media-Group/Covid-19-API) | 국가별 코로나19 사례, 사망자 및 회복자 | No | Yes | Yes |
+| [Covid-19 Datenhub](https://npgeo-corona-npgeo-de.hub.arcgis.com) | 코로나19와 관련된 지도, 데이터 세트, 애플리케이션 등 | No | Yes | Unknown |
+| [Covid-19 Government Response](https://covidtracker.bsg.ox.ac.uk) | 코로나19 팬데믹에 맞서 싸우기 위한 정부 조치 추적기 | No | Yes | Yes |
+| [Covid-19 India](https://data.covid19india.org/) | 인도 내 사례, 예방 접종, 회복에 대한 주 및 지역별 코비드 19 통계 | No | Yes | Unknown |
+| [Covid-19 JHU CSSE](https://nuttaphat.com/covid19-api/) | JHU CSSE를 기반으로 코로나19 사례를 탐색하기 위한 오픈 소스 API | No | Yes | Yes |
+| [Covid-19 Live Data](https://github.com/mathdroid/covid-19-api) | 코로나19 일일 요약, 확인 사례, 회복자 및 사망에 대한 전 세계 및 국가별 데이터 | No | Yes | Yes |
+| [Covid-19 Philippines](https://github.com/Simperfy/Covid-19-API-Philippines-DOH) | DOH에서 수집한 데이터로 만든 필리핀용 비공식 코로나19 웹 API | No | Yes | Yes |
+| [COVID-19 Tracker Canada](https://api.covid19tracker.ca/docs/1.0/overview) | 캐나다 전역의 코로나19 사례에 대한 세부정보 | No | Yes | Unknown |
+| [COVID-19 Tracker Sri Lanka](https://www.hpb.health.gov.lk/en/api-documentation) | 스리랑카에서 보고된 코로나19 환자 현황을 제공합니다. | No | Yes | Unknown |
+| [COVID-ID](https://data.covid19.go.id/public/api/prov.json) | 인도네시아 정부 주별 코비드 데이터 | No | Yes | Yes |
+| [Dataflow Kit COVID-19](https://covid-19.dataflowkit.com) | 시간당 사이트에 대한 코로나19 실시간 통계 | No | Yes | Unknown |
+| [Edamam](https://developer.edamam.com/) | 레시피 검색 | `apiKey` | Yes | Unknown |
+| [FoodData Central](https://fdc.nal.usda.gov/) | 표준 참조를 위한 국립 영양소 데이터베이스 | `apiKey` | Yes | Unknown |
+| [Healthcare.gov](https://www.healthcare.gov/developers/) | 미국 건강보험 마켓플레이스에 대한 교육 콘텐츠 | No | Yes | Unknown |
+| [Humanitarian Data Exchange](https://data.humdata.org/) | HDX(Humanitarian Data Exchange)는 위기 상황과 조직 전반에 걸쳐 데이터를 공유하기 위한 개방형 플랫폼입니다. | No | Yes | Unknown |
+| [Infermedica](https://developer.infermedica.com/docs/) | 텍스트를 통한 건강 진단을 위한 NLP 기반 증상 검사기 및 환자 분류 API | `apiKey` | Yes | Yes |
+| [LAPIS](https://cov-spectrum.ethz.ch/public) | 공개 소스의 SARS-CoV-2 게놈 서열 | No | Yes | Yes |
+| [Lexigram](https://docs.lexigram.io/) | 텍스트에서 임상 개념에 대한 언급을 추출하는 NLP는 임상 온톨로지에 대한 액세스를 제공합니다. | `apiKey` | Yes | Unknown |
+| [Makeup](http://makeup-api.herokuapp.com/) | 화장품 정보 | No | No | Unknown |
+| [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u) | 말레이시아의 예방접종 데이터 | No | Yes | Unknown |
+| [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | 미국에 등록된 의료 제공자 정보에 대한 국가 계획 및 제공자 열거 시스템 | No | Yes | Unknown |
+| [Nutritionix](https://developer.nutritionix.com/) | 세계 최대 검증된 영양 데이터베이스 | `apiKey` | Yes | Unknown |
+| [Open Data NHS Scotland](https://www.opendata.nhs.scot) | 스코틀랜드 공중 보건의 의료 참고 데이터 및 통계 | No | Yes | Unknown |
+| [Open Disease](https://disease.sh/) | 현재 사례와 코로나19 및 인플루엔자에 관한 추가 정보를 위한 API | No | Yes | Yes |
+| [openFDA](https://open.fda.gov) | 의약품, 의료기기 및 식품에 대한 공개 FDA 데이터 | `apiKey` | Yes | Unknown |
+| [Orion Health](https://developer.orionhealth.io/) | 다양한 의료 시나리오에 대한 애플리케이션 개발을 가능하게 하는 의료 플랫폼 | `OAuth` | Yes | Unknown |
+| [Quarantine](https://quarantine.country/coronavirus/api/) | 무료 코로나19 라이브 업데이트가 포함된 코로나바이러스 API | No | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 채용
 
-|                                           API                                            | 설명                                                                  |   인증   | HTTPS |  CORS   |
-| :--------------------------------------------------------------------------------------: | --------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                     [Adzuna](https://developer.adzuna.com/overview)                      | 구인 게시판 집계기                                                    | `apiKey` |  Yes  | Unknown |
-|                   [Careerjet](https://www.careerjet.com/partners/api/)                   | 구인 검색 엔진                                                        | `apiKey` |  No   | Unknown |
-|                     [DevITjobs](https://devitjobs.us/api/jobsLight)                      | 소프트웨어 개발자를 위한 채용정보                                     |    No    |  Yes  | Unknown |
-|                         [GraphQL Jobs](https://api.graphql.jobs)                         | GraphQL 관련 채용정보                                                 |    No    |  Yes  |   Yes   |
-|                        [Indeed](https://www.indeed.com/publisher)                        | 구인 게시판 집계기                                                    | `apiKey` |  Yes  | Unknown |
-|                        [Jobicy](https://jobicy.com/jobs-rss-feed)                        | 다양한 산업 및 회사의 최신 원격 채용 목록                             |    No    |  Yes  |   Yes   |
-|                 [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf)                 | 구인 집계기                                                           | `apiKey` |  Yes  | Unknown |
-|                       [Juju](http://www.juju.com/publisher/spec/)                        | 구인 검색 엔진                                                        | `apiKey` |  No   | Unknown |
-|                              [OkJob](https://okjob.io/api)                               | 주 4일 근무 구인 게시판                                               | `apiKey` |  Yes  | Unknown |
-| [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | 직업명, 기술 및 관련 직업 데이터                                      |    No    |  No   | Unknown |
-|                        [Reed](https://www.reed.co.uk/developers)                         | 구인 게시판 집계기                                                    | `apiKey` |  Yes  | Unknown |
-|                [Search.gov Jobs](https://search.gov/developer/jobs.html)                 | 미국 정부와 함께하는 현재 구인 목록 활용                              |    No    |  Yes  | Unknown |
-|                  [The Muse](https://www.themuse.com/developers/api/v2)                   | 구인 게시판 및 회사 프로필                                            | `apiKey` |  Yes  | Unknown |
-|                         [Upwork](https://developers.upwork.com/)                         | 프리랜서 구인 게시판 및 관리 시스템                                   | `OAuth`  |  Yes  | Unknown |
-|                        [USAJOBS](https://developer.usajobs.gov/)                         | 미국 정부 구인 게시판                                                 | `apiKey` |  Yes  | Unknown |
-|                 [ZipRecruiter](https://www.ziprecruiter.com/publishers)                  | 구인 검색 앱 및 웹사이트                                              | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [AI Dev Jobs](https://aidevboard.com/openapi.yaml) | REST, RSS 및 MCP 엔드포인트가 있는 AI/ML 엔지니어링 작업 수집기 | No | Yes | Yes |
+| [Adzuna](https://developer.adzuna.com/overview) | 구인 게시판 집계기 | `apiKey` | Yes | Unknown |
+| [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | 유럽/원격 구인 게시판 수집기용 API | No | Yes | Yes |
+| [Arbeitsamt](https://jobsuche.api.bund.dev/) | 독일 구인 게시판 수집기인 "Arbeitsamt"용 API | `OAuth` | Yes | Unknown |
+| [Careerjet](https://www.careerjet.com/partners/api/) | 구인 검색 엔진 | `apiKey` | No | Unknown |
+| [DevITjobs UK](https://devitjobs.uk/job_feed.xml) | GraphQL을 사용한 작업 | No | Yes | Yes |
+| [Findwork](https://findwork.dev/developers/) | 직업 게시판 | `apiKey` | Yes | Unknown |
+| [GraphQL Jobs](https://graphql.jobs/docs/api/) | GraphQL을 사용한 작업 | No | Yes | Yes |
+| [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | 구인 집계기 | `apiKey` | Yes | Unknown |
+| [Jooble](https://jooble.org/api/about) | 직업 검색 엔진 | `apiKey` | Yes | Unknown |
+| [Juju](http://www.juju.com/publisher/spec/) | 구인 검색 엔진 | `apiKey` | No | Unknown |
+| [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | 직업명, 기술 및 관련 직업 데이터 | No | No | Unknown |
+| [Reed](https://www.reed.co.uk/developers) | 구인 게시판 집계기 | `apiKey` | Yes | Unknown |
+| [The Muse](https://www.themuse.com/developers/api/v2) | 구인 게시판 및 회사 프로필 | `apiKey` | Yes | Unknown |
+| [Upwork](https://developers.upwork.com/) | 프리랜서 구인 게시판 및 관리 시스템 | `OAuth` | Yes | Unknown |
+| [USAJOBS](https://developer.usajobs.gov/) | 미국 정부 구인 게시판 | `apiKey` | Yes | Unknown |
+| [WhatJobs](https://www.whatjobs.com/affiliates) | 직업 검색 엔진 | `apiKey` | Yes | Unknown |
+| [ZipRecruiter](https://www.ziprecruiter.com/publishers) | 구인 검색 앱 및 웹사이트 | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 기계 학습
 
-|                                        API                                        | 설명                                        |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------------------------------------: | ------------------------------------------- | :------: | :---: | :-----: |
-| [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | 이미지 캡션, 얼굴 인식, NSFW 분류           | `apiKey` |  Yes  |   Yes   |
-|          [Deepcode](https://www.deepcode.ai/docs/Overview%252FOverview)           | 코드 리뷰를 위한 AI                         |    No    |  Yes  | Unknown |
-|                       [Dialogflow](https://dialogflow.com)                        | 자연어 처리                                 | `apiKey` |  Yes  | Unknown |
-|                            [Keen IO](https://keen.io/)                            | 데이터 분석                                 | `apiKey` |  Yes  | Unknown |
-|                     [Unplugg](https://unplu.gg/test_api.html)                     | 시계열 데이터 예측 API                      | `apiKey` |  Yes  | Unknown |
-|                             [Wit.ai](https://wit.ai/)                             | 자연어 처리                                 | `OAuth`  |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [AI For Thai](https://aiforthai.in.th/index.php) | 무료 다양한 태국어 AI API | `apiKey` | Yes | Yes |
+| [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | 컴퓨터 비전 | `OAuth` | Yes | Unknown |
+| [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | 이미지 캡션, 얼굴 인식, NSFW 분류 | `apiKey` | Yes | Yes |
+| [DeepAI](https://deepai.org/) | 텍스트 생성, 이미지 처리 등을 위한 AI 기반 API 제공 | `apiKey` | Yes | Yes |
+| [Deepcode](https://www.deepcode.ai) | 코드 검토를 위한 AI | No | Yes | Unknown |
+| [Dialogflow](https://cloud.google.com/dialogflow/docs/) | 자연어 처리 | `apiKey` | Yes | Unknown |
+| [EXUDE-API](http://uttesh.com/exude-api/) | 텍스트 데이터에서 중지 단어, 파생 단어를 필터링하는 기본 방법에 사용됩니다. | No | Yes | Yes |
+| [Groq](https://console.groq.com/docs/quickstart) | 무료 등급의 빠른 AI 추론 API, Llama, Mixtral, Gemma 모델 지원 | `apiKey` | Yes | Yes |
+| [Hirak FaceAPI](https://faceapi.hirak.site/) | 얼굴 인식, 연령 추정/성별 추정을 통한 얼굴 인식, 정확, 할당량 제한 없음 | `apiKey` | Yes | Unknown |
+| [Hugging Face](https://huggingface.co) | NLP, 컴퓨터 비전 및 오디오용 추론 API를 갖춘 AI 모델 허브 | `apiKey` | Yes | Yes |
+| [Imagga](https://imagga.com/) | 태깅, 시각적 검색, NSFW 조정과 같은 이미지 인식 솔루션 | `apiKey` | Yes | Unknown |
+| [Inferdo](https://rapidapi.com/user/inferdo) | 얼굴 감지, 이미지 라벨링, NSFW 분류와 같은 컴퓨터 비전 서비스 | `apiKey` | Yes | Unknown |
+| [IPS Online](https://docs.identity.ps/docs) | 얼굴 및 번호판 익명화 | `apiKey` | Yes | Unknown |
+| [Irisnet](https://irisnet.de/api/) | 원치 않는 이미지를 실시간으로 차단하거나 흐리게 처리하는 실시간 콘텐츠 조정 API | `apiKey` | Yes | Yes |
+| [Keen IO](https://keen.io/) | 데이터 분석 | `apiKey` | Yes | Unknown |
+| [Machinetutors](https://www.machinetutors.com/portfolio/MT_api.html) | AI 솔루션: 비디오/이미지 분류 및 태깅, NSFW, 아이콘/이미지/오디오 검색, NLP | `apiKey` | Yes | Yes |
+| [MessengerX.io](https://messengerx.rtfd.io) | 개발자가 맞춤형 ML 기반 채팅 앱을 구축하고 수익을 창출할 수 있는 무료 API | `apiKey` | Yes | Yes |
+| [NLP Cloud](https://nlpcloud.io) | NER, 감정, 분류, 요약 등을 위해 spaCy 및 변환기를 사용하는 NLP API | `apiKey` | Yes | Unknown |
+| [OpenVisionAPI](https://openvisionapi.com) | 오픈 소스 모델 기반의 오픈 소스 컴퓨터 비전 API | No | Yes | Yes |
+| [Perspective](https://perspectiveapi.com) | 텍스트가 독성이 있거나 외설적이거나 모욕적이거나 위협적인 경우 확률을 반환하는 NLP API | `apiKey` | Yes | Unknown |
+| [Roboflow Universe](https://universe.roboflow.com) | 사전 훈련된 컴퓨터 비전 모델 | `apiKey` | Yes | Yes |
+| [SkyBiometry](https://skybiometry.com/documentation/) | 얼굴 감지, 얼굴 인식 및 얼굴 그룹화 | `apiKey` | Yes | Unknown |
+| [TensorFeed](https://tensorfeed.ai/developers) | 실시간 AI 뉴스, 모델 가격, 서비스 상태, 에이전트 활동 피드 | No | Yes | Yes |
+| [Time Door](https://timedoor.io) | 시계열 분석 API | `apiKey` | Yes | Yes |
+| [Unplugg](https://unplu.gg/test_api.html) | 시계열 데이터 예측 API | `apiKey` | Yes | Unknown |
+| [WolframAlpha](https://products.wolframalpha.com/api/) | 데이터와 알고리즘을 활용하여 질문에 대한 구체적인 답변을 제공합니다. | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 음악
 
-|                                                       API                                                        | 설명                                                                         |   인증   | HTTPS |  CORS   |
-| :--------------------------------------------------------------------------------------------------------------: | ---------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                                [AI Mastering](https://aimastering.com/api_docs/)                                 | 자동화된 음악 마스터링                                                       | `apiKey` |  Yes  |   Yes   |
-|                    [Bandsintown](https://app.swaggerhub.com/apis/Bandsintown/PublicAPI/3.0.1)                    | 음악 이벤트                                                                  |    No    |  Yes  | Unknown |
-|                                   [Deezer](https://developers.deezer.com/api)                                    | 음악                                                                         | `OAuth`  |  Yes  | Unknown |
-|                                  [Discogs](https://www.discogs.com/developers/)                                  | 음악                                                                         | `OAuth`  |  Yes  | Unknown |
-|                                   [Freesound](https://freesound.org/docs/api/)                                   | 음악 샘플                                                                    | `apiKey` |  Yes  | Unknown |
-|                                        [Genius](https://docs.genius.com/)                                        | 크라우드소싱된 가사 및 음악 지식                                             | `OAuth`  |  Yes  | Unknown |
-|                               [Genrenator](https://binaryjazz.us/genrenator-api/)                                | 음악 장르 생성기                                                             |    No    |  Yes  | Unknown |
-| [iTunes Search](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/) | 소프트웨어 제품                                                              |    No    |  Yes  | Unknown |
-|                                [Jamendo](https://developer.jamendo.com/v3.0/docs)                                | 음악                                                                         | `OAuth`  |  Yes  | Unknown |
-|                                       [KKBOX](https://developer.kkbox.com)                                       | KKBOX 플랫폼의 음악 라이브러리, 플레이리스트, 차트 가져오기 및 수행          | `OAuth`  |  Yes  | Unknown |
-|                                        [LastFm](https://www.last.fm/api)                                         | 음악                                                                         | `apiKey` |  Yes  | Unknown |
-|                                  [Lyrics.ovh](http://docs.lyricsovh.apiary.io/)                                  | 노래 가사를 검색하는 간단한 API                                              |    No    |  Yes  | Unknown |
-|                                 [Mixcloud](https://www.mixcloud.com/developers/)                                 | 음악                                                                         | `OAuth`  |  Yes  |   Yes   |
-|                 [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2)                 | 음악                                                                         |    No    |  Yes  | Unknown |
-|                                 [Musixmatch](https://developer.musixmatch.com/)                                  | 음악                                                                         | `apiKey` |  Yes  | Unknown |
-|                               [Openwhyd](https://openwhyd.github.io/openwhyd/API)                                | 스트리밍 트랙의 큐레이션된 플레이리스트 다운로드 (YouTube, SoundCloud 등)    |   `No`   |  Yes  |   No    |
-|                             [SearchLy](https://www.github.com/AlbertSuarez/searchly)                             | 노래 가사 기반 유사성 검색                                                   |   `No`   |  Yes  | Unknown |
-|                                 [Songkick](https://www.songkick.com/developer/)                                  | 음악 이벤트                                                                  | `OAuth`  |  Yes  | Unknown |
-|                                 [Songsterr](https://www.songsterr.com/a/wa/api/)                                 | 기타, 베이스 및 드럼 탭과 코드 제공                                          |    No    |  Yes  | Unknown |
-|                                 [SoundCloud](https://developers.soundcloud.com/)                                 | 사용자가 사운드를 업로드하고 공유할 수 있게 함                               | `OAuth`  |  Yes  | Unknown |
-|                       [Spotify](https://beta.developer.spotify.com/documentation/web-api/)                       | Spotify 음악 카탈로그 보기, 사용자 라이브러리 관리, 추천 등                  | `OAuth`  |  Yes  | Unknown |
-|                                   [TasteDive](https://tastedive.com/read/api)                                    | 유사한 아티스트 API (영화 및 TV 쇼에도 작동)                                 | `apiKey` |  Yes  | Unknown |
-|                              [TheAudioDB](https://www.theaudiodb.com/api_guide.php)                              | 음악                                                                         | `apiKey` |  Yes  | Unknown |
-|                                  [Vagalume](https://api.vagalume.com.br/docs/)                                   | 크라우드소싱된 가사 및 음악 지식                                             | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [7digital](https://docs.7digital.com/reference) | 뮤직스토어 7digital의 API | `OAuth` | Yes | Unknown |
+| [AI Mastering](https://aimastering.com/api_docs/) | 자동화된 음악 마스터링 | `apiKey` | Yes | Yes |
+| [Audiomack](https://www.audiomack.com/data-api/docs) | 스트리밍 음악 허브 Audiomack의 API | `OAuth` | Yes | Unknown |
+| [Bandcamp](https://bandcamp.com/developer) | 뮤직스토어 밴드캠프 API | `OAuth` | Yes | Unknown |
+| [Bandsintown](https://app.swaggerhub.com/apis/Bandsintown/PublicAPI/3.0.0) | 음악 이벤트 | No | Yes | Unknown |
+| [Deezer](https://developers.deezer.com/api) | 음악 | `OAuth` | Yes | Unknown |
+| [Discogs](https://www.discogs.com/developers/) | 음악 | `OAuth` | Yes | Unknown |
+| [Freesound](https://freesound.org/docs/api/) | 음악 샘플 | `apiKey` | Yes | Unknown |
+| [Gaana](https://github.com/cyberboysumanjay/GaanaAPI) | Gaana에서 노래 정보를 검색하는 API | No | Yes | Unknown |
+| [Genius](https://docs.genius.com/) | 크라우드소싱된 가사 및 음악 지식 | `OAuth` | Yes | Unknown |
+| [Genrenator](https://binaryjazz.us/genrenator-api/) | 음악 장르 생성기 | No | Yes | Unknown |
+| [iTunes Search](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/) | 소프트웨어 제품 | No | Yes | Unknown |
+| [Jamendo](https://developer.jamendo.com/v3.0/docs) | 음악 | `OAuth` | Yes | Unknown |
+| [JioSaavn](https://github.com/cyberboysumanjay/JioSaavnAPI) | JioSaavn에서 노래 정보, 앨범 메타 데이터 등을 검색하는 API | No | Yes | Unknown |
+| [KKBOX](https://developer.kkbox.com) | KKBOX 플랫폼의 음악 라이브러리, 플레이리스트, 차트 가져오기 및 수행 | `OAuth` | Yes | Unknown |
+| [KSoft.Si Lyrics](https://docs.ksoft.si/api/lyrics-api) | 노래 가사를 가져오는 API | `apiKey` | Yes | Unknown |
+| [LastFm](https://www.last.fm/api) | 음악 | `apiKey` | Yes | Unknown |
+| [Lyrics.ovh](https://lyricsovh.docs.apiary.io) | 노래 가사를 검색하는 간단한 API | No | Yes | Unknown |
+| [Mixcloud](https://www.mixcloud.com/developers/) | 음악 | `OAuth` | Yes | Yes |
+| [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) | 음악 | No | Yes | Unknown |
+| [Musixmatch](https://developer.musixmatch.com/) | 음악 | `apiKey` | Yes | Unknown |
+| [Napster](https://developer.napster.com/api/v2.2) | 음악 | `apiKey` | Yes | Yes |
+| [Openwhyd](https://openwhyd.github.io/openwhyd/API) | 스트리밍 트랙의 큐레이션된 플레이리스트 다운로드 (YouTube, SoundCloud 등) | No | Yes | No |
+| [Phishin](https://phish.in/api-docs) | 즉흥 록 밴드 Phish의 합법적인 라이브 오디오 녹음을 담은 웹 기반 아카이브입니다. | `apiKey` | Yes | No |
+| [Radio Browser](https://api.radio-browser.info/) | 인터넷 라디오 방송국 목록 | No | Yes | Yes |
+| [Songkick](https://www.songkick.com/developer/) | 음악 이벤트 | `apiKey` | Yes | Unknown |
+| [Songlink / Odesli](https://www.notion.so/API-d0ebe08a5e304a55928405eb682f6741) | 노래를 사용할 수 있는 모든 서비스를 이용하세요 | `apiKey` | Yes | Yes |
+| [Songsterr](https://www.songsterr.com/a/wa/api/) | 기타, 베이스 및 드럼 탭과 코드 제공 | No | Yes | Unknown |
+| [SoundCloud](https://developers.soundcloud.com/docs/api/guide) | SoundCloud API를 사용하면 콘텐츠를 제어하는 ​​데 더 많은 기능을 제공하는 애플리케이션을 구축할 수 있습니다. | `OAuth` | Yes | Unknown |
+| [Spotify](https://beta.developer.spotify.com/documentation/web-api/) | Spotify 음악 카탈로그 보기, 사용자 라이브러리 관리, 추천 등 | `OAuth` | Yes | Unknown |
+| [Sunor](https://docs.sunor.cc) | 선불 크레딧을 사용하는 Suno를 통한 AI 음악 생성 API | `apiKey` | Yes | Unknown |
+| [TasteDive](https://tastedive.com/read/api) | 유사한 아티스트 API (영화 및 TV 쇼에도 작동) | `apiKey` | Yes | Unknown |
+| [TheAudioDB](https://www.theaudiodb.com/api_guide.php) | 음악 | `apiKey` | Yes | Unknown |
+| [Vagalume](https://api.vagalume.com.br/docs/) | 크라우드소싱된 가사 및 음악 지식 | `apiKey` | Yes | Unknown |
+| [Verome](https://github.com/Kirazul/Verome-API) | YouTube Music, YouTube, Last.fm의 음악 데이터를 검색, 스트리밍, 탐색하기 위한 Music API | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 뉴스
 
-|                                 API                                 | 설명                                                              |   인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------------------: | ----------------------------------------------------------------- | :------: | :---: | :-----: |
-|            [Associated Press](https://developer.ap.org/)            | Associated Press의 뉴스 및 메타데이터 검색                        | `apiKey` |  Yes  | Unknown |
-| [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | 의회 도서관의 수백만 페이지에 달하는 미국 역사 신문 액세스        |    No    |  No   | Unknown |
-|              [Currents](https://currentsapi.services/)              | 다양한 뉴스 소스, 블로그 및 포럼에서 발행된 최신 뉴스             | `apiKey` |  Yes  |   Yes   |
-|          [Feedbin](https://github.com/feedbin/feedbin-api)          | RSS 리더                                                          | `OAuth`  |  Yes  | Unknown |
-|                   [Finlight](https://finlight.me)                   | 감정 및 기사 내용이 포함된 실시간 금융 뉴스                       | `apiKey` |  Yes  |   Yes   |
-|          [New York Times](https://developer.nytimes.com/)           | 뉴스 제공                                                         | `apiKey` |  Yes  | Unknown |
-|                    [News](https://newsapi.org/)                     | 다양한 뉴스 소스 및 블로그에서 현재 발행되는 헤드라인             | `apiKey` |  Yes  | Unknown |
-|                     [OkSurf](https://ok.surf/)                      | OG 이미지가 포함된 무료 Google 뉴스                               |    No    |  Yes  |   Yes   |
-|        [The Guardian](http://open-platform.theguardian.com/)        | 태그와 섹션별로 분류된 The Guardian이 만드는 모든 콘텐츠에 액세스  | `apiKey` |  Yes  | Unknown |
-|        [The Old Reader](https://github.com/theoldreader/api)        | RSS 리더                                                          | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Mediastack](https://mediastack.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 실시간 뉴스 및 블로그 기사를 위한 간단한 무료 REST API | `apiKey` | Yes | Unknown |
+| [Associated Press](https://developer.ap.org/) | Associated Press의 뉴스 및 메타데이터 검색 | `apiKey` | Yes | Unknown |
+| [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | 의회 도서관의 수백만 페이지에 달하는 미국 역사 신문 액세스 | No | No | Unknown |
+| [Currents](https://currentsapi.services/) | 다양한 뉴스 소스, 블로그 및 포럼에서 발행된 최신 뉴스 | `apiKey` | Yes | Yes |
+| [Feedbin](https://github.com/feedbin/feedbin-api) | RSS 리더 | `OAuth` | Yes | Unknown |
+| [Florida Man](https://github.com/juliayxhuang/florida-man-api#readme) | 날짜별 10,000개 이상의 Florida Man 헤드라인으로 구성된 정적 JSON 데이터세트 | No | Yes | Yes |
+| [GNews](https://gnews.io/) | 다양한 출처의 뉴스 검색 | `apiKey` | Yes | Yes |
+| [Graphs for Coronavirus](https://corona.dnsforfamily.com/api.txt) | 코로나바이러스에 대한 각 국가별 및 전세계 그래프. 일일 업데이트 | No | Yes | Yes |
+| [Inshorts News](https://github.com/cyberboysumanjay/Inshorts-News-API) | 인쇼츠의 소식을 제공합니다 | No | Yes | Unknown |
+| [MarketAux](https://www.marketaux.com/) | 태그된 티커 + 감정 및 통계 JSON API가 포함된 실시간 주식 시장 뉴스 | `apiKey` | Yes | Yes |
+| [New York Times](https://developer.nytimes.com/) | 뉴스 제공 | `apiKey` | Yes | Unknown |
+| [News](https://newsapi.org/) | 다양한 뉴스 소스 및 블로그에서 현재 발행되는 헤드라인 | `apiKey` | Yes | Unknown |
+| [NewsData](https://newsdata.io/docs) | 유명 뉴스 소스의 실시간 속보 및 헤드라인을 위한 뉴스 데이터 API | `apiKey` | Yes | Unknown |
+| [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | ML 기반 요약으로 최신 속보를 얻거나 검색하세요 🤖 | `apiKey` | Yes | Unknown |
+| [NPR One](http://dev.npr.org/api/) | NPR의 맞춤형 뉴스 청취 경험 | `OAuth` | Yes | Unknown |
+| [Spaceflight News](https://spaceflightnewsapi.net) | 우주 비행 관련 뉴스 🚀 | No | Yes | Yes |
+| [The Guardian](http://open-platform.theguardian.com/) | 태그와 섹션별로 분류된 The Guardian이 만드는 모든 콘텐츠에 액세스 | `apiKey` | Yes | Unknown |
+| [The Old Reader](https://github.com/theoldreader/api) | RSS 리더 | `apiKey` | Yes | Unknown |
+| [TheNews](https://www.thenewsapi.com/) | 집계된 헤드라인, 주요 기사 및 실시간 뉴스 JSON API | `apiKey` | Yes | Yes |
+| [Trove](https://trove.nla.gov.au/about/create-something/using-api) | 1000개에 달하는 디지털 신문 컬렉션을 호주 국립도서관에서 검색하세요. | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 오픈 데이터
 
-|                                     API                                     | 설명                                                                                        |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                 [18F](http://18f.github.io/API-All-the-X/)                  | 비공식 미국 연방 정부 API 개발                                                              |    No    |  No   | Unknown |
-|                [Archive.org](https://archive.readme.io/docs)                | 인터넷 아카이브                                                                             |    No    |  Yes  | Unknown |
-|                    [Callook.info](https://callook.info)                     | 미국 아마추어 무선 호출부호                                                                 |    No    |  Yes  | Unknown |
-|                         [CARTO](https://carto.com/)                         | 위치 정보 예측                                                                              | `apiKey` |  Yes  | Unknown |
-|               [CivicFeed](https://developers.civicfeed.com/)                | 뉴스 기사 및 공공 데이터셋                                                                  | `apiKey` |  Yes  | Unknown |
-|     [Enigma Public](http://docs.enigma.com/public/public_v20_api_about)     | 가장 광범위한 공공 데이터 컬렉션                                                            | `apiKey` |  Yes  |   Yes   |
-|                  [fonoApi](https://fonoapi.freshpixl.com/)                  | 모바일 기기 설명                                                                            |    No    |  Yes  | Unknown |
-|          [French Address Search](https://geo.api.gouv.fr/adresse)           | 프랑스 정부를 통한 주소 검색                                                               |    No    |  Yes  | Unknown |
-|              [Fruits](https://fruits-api.netlify.app/graphql)               | 세계 과일나무에 대한 정보                                                                   |    No    |  Yes  |   No    |
-|                 [LinkPreview](https://www.linkpreview.net)                  | 요청된 URL에 대한 제목, 설명 및 미리보기 이미지가 포함된 JSON 형식 요약 제공               | `apiKey` |  Yes  |   Yes   |
-|                    [Microlink.io](https://microlink.io)                     | 모든 웹사이트에서 구조화된 데이터 추출                                                      |    No    |  Yes  |   Yes   |
-| [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | 여러 국가의 기업 엔티티 및 임원에 대한 데이터                                               | `apiKey` |  Yes  | Unknown |
-|                      [Quandl](https://www.quandl.com/)                      | 주식 시장 데이터                                                                            |    No    |  Yes  | Unknown |
-|       [Recreation Information Database](https://ridb.recreation.gov/)       | 레크리에이션 지역, 연방 토지, 역사적 명소, 박물관 및 기타 명소/자원(미국)                   | `apiKey` |  Yes  | Unknown |
-|                     [Scoop.it](http://www.scoop.it/dev)                     | 콘텐츠 큐레이션 서비스                                                                      | `apiKey` |  No   | Unknown |
-|                [Teleport](https://developers.teleport.org/)                 | 삶의 질 데이터                                                                              |    No    |  Yes  | Unknown |
-|    [Universities List](https://github.com/Hipo/university-domains-list)     | 대학 이름, 국가 및 도메인                                                                   |    No    |  Yes  | Unknown |
-|                 [University of Oslo](https://data.uio.no/)                  | 오슬로 대학교(노르웨이)의 과정, 강의 비디오, 과정 상세 정보 등                              |    No    |  Yes  | Unknown |
-|                 [UPC database](https://upcdatabase.org/api)                 | 전 세계 150만 개 이상의 바코드 번호                                                         | `apiKey` |  Yes  | Unknown |
-|         [Wikidata](https://www.wikidata.org/w/api.php?action=help)          | 위키미디어 재단에서 운영하는 공동 편집 지식 베이스                                          | `OAuth`  |  Yes  | Unknown |
-|          [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page)          | 미디어위키 백과사전                                                                         |    No    |  Yes  | Unknown |
-|          [Yelp](https://www.yelp.com/developers/documentation/v3)           | 지역 비즈니스 찾기                                                                          | `OAuth`  |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [18F](http://18f.github.io/API-All-the-X/) | 비공식 미국 연방 정부 API 개발 | No | No | Unknown |
+| [AcreLens](https://www.acrelens.com) | 모든 미국 부동산에 대한 토지 적합성 점수 API: 독립형, 농촌, 레크리에이션, 투자 | `apiKey` | Yes | Unknown |
+| [API Setu](https://www.apisetu.gov.in/) | KYC, 비즈니스, 교육 및 고용을 위해 많은 APIS를 제공하는 인도 정부 플랫폼 | No | Yes | Yes |
+| [Archive.org](https://archive.readme.io/docs) | 인터넷 아카이브 | No | Yes | No |
+| [Black History Facts](https://www.blackhistoryapi.io/docs) | 웹에서 가장 큰 흑인 역사 사실 데이터베이스 중 하나를 제공하거나 검색하세요. | `apiKey` | Yes | Yes |
+| [BotsArchive](https://botsarchive.com/docs.html) | 데이터베이스에서 사용 가능한 Telegram Bots에 대한 JSON 형식의 세부 정보 | No | Yes | Unknown |
+| [Callook.info](https://callook.info) | 미국 아마추어 무선 호출부호 | No | Yes | Unknown |
+| [CARTO](https://carto.com/) | 위치 정보 예측 | `apiKey` | Yes | Unknown |
+| [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | 미국의 고등교육기관에 관한 데이터 | No | Yes | Unknown |
+| [Enigma Public](https://developers.enigma.com/docs) | 가장 광범위한 공공 데이터 수집 | `apiKey` | Yes | Yes |
+| [French Address Search](https://geo.api.gouv.fr/adresse) | 프랑스 정부를 통한 주소 검색 | No | Yes | Unknown |
+| [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | 독일 연방통계청 | `OAuth` | Yes | Unknown |
+| [Joshua Project](https://api.joshuaproject.net/) | 그리스도를 따르는 사람들이 가장 적은 세계의 종족 그룹 | `apiKey` | Yes | Unknown |
+| [Kaggle](https://www.kaggle.com/docs/api) | 데이터 세트, 노트북을 생성 및 상호 작용하고 Kaggle과 연결 | `apiKey` | Yes | Unknown |
+| [LinkPreview](https://www.linkpreview.net) | 요청된 URL에 대한 제목, 설명 및 미리보기 이미지가 포함된 JSON 형식 요약 제공 | `apiKey` | Yes | Yes |
+| [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs) | 측정 자원과 영향력을 확보하여 아시아 국가의 상대적 권력 순위를 매기세요. | No | Yes | Unknown |
+| [Microlink.io](https://microlink.io) | 모든 웹사이트에서 구조화된 데이터 추출 | No | Yes | Yes |
+| [ModelPartFinder Error Codes](https://modelpartfinder.com/docs/api) | 브랜드별, 코드별 기기 및 장비 오류 코드 조회, 권장 교체 부품 포함 | No | Yes | Yes |
+| [Nasdaq Data Link](https://docs.data.nasdaq.com/) | 주식 시장 데이터 | `apiKey` | Yes | Unknown |
+| [Nobel Prize](https://www.nobelprize.org/about/developer-zone-2/) | 노벨상 및 행사에 대한 공개 데이터 | No | Yes | Yes |
+| [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) | Coinbase CDP 검색 API에서 색인된 x402 유료 HTTP 서비스의 무료 공개 리더보드 | No | Yes | Unknown |
+| [Open Data Minneapolis](https://opendata.minneapolismn.gov/) | 미니애폴리스의 공간(GIS) 및 비공간 도시 데이터 | No | Yes | No |
+| [openAFRICA](https://africaopendata.org/) | 아프리카 오픈 데이터의 대규모 데이터 세트 저장소 | No | Yes | Unknown |
+| [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | 여러 국가의 기업 엔티티 및 임원에 대한 데이터 | `apiKey` | Yes | Unknown |
+| [OpenSanctions](https://www.opensanctions.org/docs/api/) | 국제 제재, 범죄, 정치적으로 노출된 인물에 관한 데이터 | No | Yes | Yes |
+| [PeakMetrics](https://rapidapi.com/peakmetrics-peakmetrics-default/api/peakmetrics-news) | 뉴스 기사 및 공개 데이터세트 | `apiKey` | Yes | Unknown |
+| [Recreation Information Database](https://ridb.recreation.gov/) | 레크리에이션 지역, 연방 토지, 역사적 명소, 박물관 및 기타 명소/자원(미국) | `apiKey` | Yes | Unknown |
+| [Scoop.it](http://www.scoop.it/dev) | 콘텐츠 큐레이션 서비스 | `apiKey` | No | Unknown |
+| [Socrata](https://dev.socrata.com/) | 전 세계 정부, 비영리 단체, NGO의 공개 데이터에 액세스 | `OAuth` | Yes | Yes |
+| [Teleport](https://developers.teleport.org/) | 삶의 질 데이터 | No | Yes | Unknown |
+| [Umeå Open Data](https://opendata.umea.se/api/) | 스웨덴 북부 우메오(Umeå) 도시의 오픈 데이터 | No | Yes | Yes |
+| [Universities List](https://github.com/Hipo/university-domains-list) | 대학 이름, 국가 및 도메인 | No | Yes | Unknown |
+| [University of Oslo](https://data.uio.no/) | 오슬로 대학교(노르웨이)의 과정, 강의 비디오, 과정 상세 정보 등 | No | Yes | Unknown |
+| [UPC database](https://upcdatabase.org/api) | 전 세계 150만 개 이상의 바코드 번호 | `apiKey` | Yes | Unknown |
+| [Urban Observatory](https://urbanobservatory.ac.uk) | 영국에서 공개적으로 이용 가능한 최대 규모의 실시간 도시 데이터 세트 | No | No | No |
+| [Voidly](https://voidly.ai/api-docs) | 126개국의 인터넷 검열 측정, 사건, ISP 수준 차단 데이터 | No | Yes | No |
+| [Wikidata](https://www.wikidata.org/w/api.php?action=help) | 위키미디어 재단에서 운영하는 공동 편집 지식 베이스 | `OAuth` | Yes | Unknown |
+| [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | 미디어위키 백과사전 | No | Yes | Unknown |
+| [Yelp](https://www.yelp.com/developers/documentation/v3) | 지역 비즈니스 찾기 | `OAuth` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 오픈 소스 프로젝트
 
-|                           API                           | 설명                             |   인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------: | -------------------------------- | :------: | :---: | :-----: |
-| [Drupal.org](https://www.drupal.org/drupalorg/docs/api) | Drupal.org                       |    No    |  Yes  | Unknown |
-|   [Evil Insult Generator](https://evilinsult.com/api)   | 악한 모독                        |    No    |  Yes  |   Yes   |
-|        [Libraries.io](https://libraries.io/api)         | 오픈 소스 소프트웨어 라이브러리  | `apiKey` |  Yes  | Unknown |
-|  [The Odin Project](https://github.com/theodinproject)  | theodinproject.com               |    No    |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Countly](https://api.count.ly/reference) | 카운티 웹 분석 | No | No | Unknown |
+| [Creative Commons Catalog](https://api.creativecommons.engineering/) | 공개 라이센스 및 퍼블릭 도메인 저작물 검색 | `OAuth` | Yes | Yes |
+| [Datamuse](https://www.datamuse.com/api/) | 단어 찾기 쿼리 엔진 | No | Yes | Unknown |
+| [Drupal.org](https://www.drupal.org/drupalorg/docs/api) | Drupal.org 프로젝트와 이슈 데이터 API | No | Yes | Unknown |
+| [Evil Insult Generator](https://evilinsult.com/api) | 악한 모독 | No | Yes | Yes |
+| [GitHub Contribution Chart Generator](https://github-contributions.vercel.app) | GitHub 기여 이미지 만들기 | No | Yes | Yes |
+| [GitHub ReadMe Stats](https://github.com/anuraghazra/github-readme-stats) | GitHub 프로필 ReadMe에 동적으로 생성된 통계를 추가하세요. | No | Yes | Yes |
+| [Metabase](https://www.metabase.com/) | 회사 내부에서 데이터와 분석을 공유하는 오픈 소스 비즈니스 인텔리전스 서버 | No | Yes | Yes |
+| [Shields](https://shields.io/) | SVG 및 래스터 형식의 간결하고 일관되며 읽기 쉬운 배지 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 특허
 
-|                                      API                                      | 설명                        |   인증   | HTTPS |  CORS   |
-| :---------------------------------------------------------------------------: | --------------------------- | :------: | :---: | :-----: |
-|                      [EPO](https://developers.epo.org/)                       | 유럽 특허 검색 시스템 API   | `OAuth`  |  Yes  | Unknown |
-| [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | 대만 특허 검색 시스템 API   | `apiKey` |  Yes  | Unknown |
-| [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility)  | 미국 특허 API 서비스        |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [EPO](https://developers.epo.org/) | 유럽 특허 검색 시스템 API | `OAuth` | Yes | Unknown |
+| [PatentsView](https://patentsview.org/apis/purpose) | API는 미국 혁신 환경 전반의 추세/패턴을 탐색하고 시각화하기 위한 것입니다. | No | Yes | Unknown |
+| [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | 대만 특허 검색 시스템 API | `apiKey` | Yes | Unknown |
+| [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility) | 미국 특허 API 서비스 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 성격
 
-|                               API                               | 설명                                                                |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------------------: | ------------------------------------------------------------------- | :------: | :---: | :-----: |
-|            [Advice Slip](http://api.adviceslip.com/)            | 랜덤 조언 슬립 생성                                                 |    No    |  Yes  | Unknown |
-|          [chucknorris.io](https://api.chucknorris.io)           | 수작업으로 큐레이션된 척 노리스 농담을 위한 JSON API                |    No    |  Yes  | Unknown |
-|              [Echoes](https://echoes.soferity.com)              | 전 세계의 명언                                                      |    No    |  Yes  |   Yes   |
-|               [FavQs.com](https://favqs.com/api)                | 좋아하는 명언을 수집, 발견, 공유할 수 있는 FavQs                    | `apiKey` |  Yes  | Unknown |
-|           [Forismatic](http://forismatic.com/en/api/)           | 영감을 주는 명언                                                    |    No    |  No   | Unknown |
-|              [HideMyMind](https://hidemymind.com/)              | 링크 액세스가 가능한 비공개 암호화 노트 서비스                      |    No    |  Yes  | Unknown |
-|        [Hindi Quotes](https://hindi-quotes.vercel.app/)         | 다양한 카테고리의 랜덤 힌디어 명언 가져오기                         |    No    |  Yes  |   Yes   |
-| [Hindi Quotes and Shayari](https://purevichar.in/tool/apitool)  | 다양한 카테고리의 힌디어 명언과 샤야리를 무료로 제공                |    No    |  No   | Unknown |
-|        [icanhazdadjoke](https://icanhazdadjoke.com/api)         | 인터넷에서 가장 큰 아빠 개그 모음                                   |    No    |  Yes  | Unknown |
-|                [kanye.rest](https://kanye.rest)                 | 랜덤 Kanye West 명언을 위한 REST API                                |    No    |  Yes  |   Yes   |
-|       [Medium](https://github.com/Medium/medium-api-docs)       | 아이디어에 대한 독특한 관점을 제공하는 독자와 작가들의 커뮤니티     | `OAuth`  |  Yes  | Unknown |
-|            [Meme](https://github.com/D3vd/Meme_Api)             | 레딧에서 스크래핑한 랜덤 밈을 위한 JSON API                         |    No    |  Yes  | Unknown |
-|        [NaMoMemes](https://github.com/theIYD/NaMoMemes)         | 나렌드라 모디에 대한 밈                                             |    No    |  Yes  | Unknown |
-| [Programming Quotes](https://programming-quotesapi.vercel.app/) | 프로그래머들의 명언을 생성하는 API                                  |    No    |  Yes  |   Yes   |
-| [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/)  | 5000개 이상의 유명한 명언을 위한 REST API                           |    No    |  Yes  | Unknown |
-|        [Quoterism](https://www.quoterism.com/developer)         | 영감을 주는 명언                                                    |    No    |  Yes  | Unknown |
-|       [Quotes on Design](https://quotesondesign.com/api/)       | 영감을 주는 명언                                                    |    No    |  Yes  | Unknown |
-|         [Riddles API](https://riddles-api.vercel.app/)          | API 호출마다 랜덤 수수께끼 가져오기                                  |    No    |  Yes  |   Yes   |
-|         [Traitify](https://app.traitify.com/developer)          | 성격 평가, 수집 및 분석                                             |    No    |  Yes  | Unknown |
-|          [tronalddump.io](https://www.tronalddump.io)           | 도널드 트럼프가 한 말들을 위한 API 및 웹 아카이브                   |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Advice Slip](http://api.adviceslip.com/) | 랜덤 조언 슬립 생성 | No | Yes | Unknown |
+| [Biriyani As A Service](https://biriyani.anoram.com/) | 비리야니 이미지 자리표시자 | No | Yes | No |
+| [Dev.to](https://developers.forem.com/api) | API를 통해 Forem 기사, 사용자 및 기타 리소스에 액세스하세요. | `apiKey` | Yes | Unknown |
+| [Dictum](https://github.com/fisenkodv/dictum) | 인류의 가장 감동적인 표현 모음에 접근할 수 있는 API | No | Yes | Unknown |
+| [FavQs.com](https://favqs.com/api) | 좋아하는 명언을 수집, 발견, 공유할 수 있는 FavQs | `apiKey` | Yes | Unknown |
+| [FOAAS](http://www.foaas.com/) | 서비스로 엿 먹어라 | No | No | Unknown |
+| [Forismatic](http://forismatic.com/en/api/) | 영감을 주는 명언 | No | No | Unknown |
+| [icanhazdadjoke](https://icanhazdadjoke.com/api) | 인터넷에서 가장 큰 아빠 개그 모음 | No | Yes | Unknown |
+| [Inspiration](https://inspiration.goprogram.ai/docs/) | 동기 부여 및 영감을 주는 인용문 | No | Yes | Yes |
+| [kanye.rest](https://kanye.rest) | 랜덤 Kanye West 명언을 위한 REST API | No | Yes | Yes |
+| [kimiquotes](https://kimiquotes.herokuapp.com/doc) | 핀란드 F1 전설 Kimi Räikkönen의 팀 라디오 및 인터뷰 인용문 | No | Yes | Yes |
+| [Medium](https://github.com/Medium/medium-api-docs) | 아이디어에 대한 독특한 관점을 제공하는 독자와 작가들의 커뮤니티 | `OAuth` | Yes | Unknown |
+| [Programming Quotes](https://github.com/skolakoda/programming-quotes-api) | 오픈 소스 프로젝트를 위한 프로그래밍 인용 API | No | Yes | Unknown |
+| [Quotable Quotes](https://github.com/lukePeavey/quotable) | Quotable은 무료 오픈 소스 견적 API. | No | Yes | Unknown |
+| [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/) | 5000개 이상의 유명한 명언을 위한 REST API | No | Yes | Unknown |
+| [quoteclear](https://quoteclear.web.app/) | 3-2-1 뉴스레터에서 점점 늘어나는 James Clear의 인용문 목록 | No | Yes | Yes |
+| [Quotes on Design](https://quotesondesign.com/api/) | 영감을 주는 명언 | No | Yes | Unknown |
+| [Stoicism Quote](https://github.com/tlcheah2/stoic-quote-lambda-public-api) | 금욕주의에 대한 인용문 | No | Yes | Unknown |
+| [They Said So Quotes](https://theysaidso.com/api/) | 인용문 전 세계 많은 포춘 브랜드가 신뢰하는 명언 | No | Yes | Unknown |
+| [Traitify](https://app.traitify.com/developer) | 성격 평가, 수집 및 분석 | No | Yes | Unknown |
+| [Udemy(instructor)](https://www.udemy.com/developers/instructor/) | Udemy 강사를 위한 API | `apiKey` | Yes | Unknown |
+| [Vadivelu HTTP Codes](https://vadivelu.anoram.com/) | 이미지가 포함된 주문형 HTTP 코드 | No | Yes | No |
+| [Zen Quotes](https://zenquotes.io/) | 영감을 주는 선 인용문의 대규모 컬렉션 | No | Yes | Yes |
+
+**[⬆ 목차로 돌아가기](#목차)**
+
+### 전화
+
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Numlookup](https://numlookupapi.com) | 전 세계적으로 적용되는 전화번호 확인 및 이동통신사 조회 API | `apiKey` | Yes | Unknown |
+| [Numverify](https://numverify.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 전화번호 검증 | `apiKey` | Yes | Unknown |
+| [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | 국제 전화번호 확인 | `apiKey` | Yes | Yes |
+| [Phone Specification](https://github.com/azharimm/phone-specs-api) | 휴대폰 사양용 Rest Api | No | Yes | Yes |
+| [Phone Validation](https://www.abstractapi.com/phone-validation-api) | 전화번호를 전 세계적으로 확인하세요. | `apiKey` | Yes | Yes |
+| [Veriphone](https://veriphone.io) | 전화번호 검증 및 통신사 조회 | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 사진
 
-|                          API                          | 설명                                             |   인증   | HTTPS |  CORS   |
-| :---------------------------------------------------: | ------------------------------------------------ | :------: | :---: | :-----: |
-|    [Flickr](https://www.flickr.com/services/api/)     | Flickr 서비스                                    | `OAuth`  |  Yes  | Unknown |
-| [Getty Images](http://developers.gettyimages.com/en/) | 세계에서 가장 강력한 이미지를 사용한 앱 구축     | `OAuth`  |  Yes  | Unknown |
-|      [Giphy](https://developers.giphy.com/docs/)      | 모든 GIF 가져오기                                | `apiKey` |  Yes  | Unknown |
-|          [Gyazo](https://gyazo.com/api/docs)          | 이미지 업로드                                    | `apiKey` |  Yes  | Unknown |
-|          [Imgur](https://apidocs.imgur.com/)          | 이미지                                           | `OAuth`  |  Yes  | Unknown |
-|        [Lorem Picsum](https://picsum.photos/)         | Unsplash의 이미지                                |    No    |  Yes  | Unknown |
-|          [ObjectCut](https://objectcut.com/)          | 이미지 배경 제거                                 | `apiKey` |  Yes  |   Yes   |
-|         [Pexels](https://www.pexels.com/api/)         | 무료 스톡 사진 및 비디오                         | `apiKey` |  Yes  |   Yes   |
-| [Pixabay](https://pixabay.com/sk/service/about/api/)  | 사진                                             | `apiKey` |  Yes  | Unknown |
-|        [PlaceKitten](https://placekitten.com/)        | 크기 조정 가능한 새끼고양이 플레이스홀더 이미지  |    No    |  Yes  | Unknown |
-|    [ScreenShotLayer](https://screenshotlayer.com)     | URL을 이미지로                                   |    No    |  Yes  | Unknown |
-|      [Unsplash](https://unsplash.com/developers)      | 사진                                             | `OAuth`  |  Yes  | Unknown |
-|      [Wallhaven](https://wallhaven.cc/help/api)       | 배경화면                                         | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Screenshotlayer](https://screenshotlayer.com?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 스크린샷 URL | No | Yes | Unknown |
+| [APITemplate.io](https://apitemplate.io) | 간단한 API를 사용하여 템플릿에서 이미지와 PDF를 동적으로 생성 | `apiKey` | Yes | Yes |
+| [Bruzu](https://docs.bruzu.com) | 쿼리 문자열을 사용한 이미지 생성 | `apiKey` | Yes | Yes |
+| [CheetahO](https://cheetaho.com/docs/getting-started/) | 사진 최적화 및 크기 조정 | `apiKey` | Yes | Unknown |
+| [Dagpi](https://dagpi.xyz) | 이미지 조작 및 처리 | `apiKey` | Yes | Unknown |
+| [Duply](https://duply.co/docs#getting-started-api) | 이미지와 비디오를 더욱 스마트하고 빠르게 생성, 편집, 확장 및 관리 | `apiKey` | Yes | Yes |
+| [DynaPictures](https://dynapictures.com/docs/) | 몇 분 만에 수백 개의 맞춤형 이미지 생성 | `apiKey` | Yes | Yes |
+| [Flickr](https://www.flickr.com/services/api/) | Flickr 서비스 | `OAuth` | Yes | Unknown |
+| [Getty Images](http://developers.gettyimages.com/en/) | 세계에서 가장 강력한 이미지를 사용한 앱 구축 | `OAuth` | Yes | Unknown |
+| [Gfycat](https://developers.gfycat.com/api/) | 지피어 GIF | `OAuth` | Yes | Unknown |
+| [Giphy](https://developers.giphy.com/docs/) | 모든 GIF 가져오기 | `apiKey` | Yes | Unknown |
+| [Google Photos](https://developers.google.com/photos) | Google 포토를 앱이나 기기와 통합하세요 | `OAuth` | Yes | Unknown |
+| [Image Upload](https://apilayer.com/marketplace/image_upload-api) | 이미지 최적화 | `apiKey` | Yes | Unknown |
+| [Imgur](https://apidocs.imgur.com/) | 이미지 | `OAuth` | Yes | Unknown |
+| [Imsea](https://imsea.herokuapp.com/) | 무료 이미지 검색 | No | Yes | Unknown |
+| [Lorem Picsum](https://picsum.photos/) | Unsplash의 이미지 | No | Yes | Unknown |
+| [ObjectCut](https://objectcut.com/) | 이미지 배경 제거 | `apiKey` | Yes | Yes |
+| [Pexels](https://www.pexels.com/api/) | 무료 스톡 사진 및 비디오 | `apiKey` | Yes | Yes |
+| [PhotoRoom](https://www.photoroom.com/api/) | 이미지에서 배경 제거 | `apiKey` | Yes | Unknown |
+| [Pixabay](https://pixabay.com/sk/service/about/api/) | 사진 | `apiKey` | Yes | Unknown |
+| [PlaceKeanu](https://placekeanu.com/) | 회색조 및 어린 Keanu 옵션이 포함된 크기 조정 가능한 Keanu Reeves 자리 표시자 이미지 | No | Yes | Unknown |
+| [Readme typing SVG](https://github.com/DenverCoder1/readme-typing-svg) | 사용자 정의 가능한 텍스트 입력 및 삭제 SVG | No | Yes | Unknown |
+| [Remove.bg](https://www.remove.bg/api) | 이미지 배경 제거 | `apiKey` | Yes | Unknown |
+| [ReSmush.it](https://resmush.it/api) | 사진 최적화 | No | No | Unknown |
+| [shutterstock](https://api-reference.shutterstock.com/) | 스톡 사진 및 비디오 | `OAuth` | Yes | Unknown |
+| [Sirv](https://apidocs.sirv.com/) | 최적화, 조작, 호스팅과 같은 이미지 관리 솔루션 | `apiKey` | Yes | Unknown |
+| [Unsplash](https://unsplash.com/developers) | 사진 | `OAuth` | Yes | Unknown |
+| [Wallhaven](https://wallhaven.cc/help/api) | 배경화면 | `apiKey` | Yes | Unknown |
+| [Webdam](https://www.damsuccess.com/hc/en-us/articles/202134055-REST-API) | 이미지 | `OAuth` | Yes | Unknown |
+
+**[⬆ 목차로 돌아가기](#목차)**
+
+### 프로그래밍
+
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Codeforces](https://codeforces.com/apiHelp) | Codeforces 데이터에 액세스하세요 | `apiKey` | Yes | Unknown |
+| [Hackerearth](https://www.hackerearth.com/docs/wiki/developers/v4/) | 여러 언어로 코드를 컴파일하고 실행하는 경우 | `apiKey` | Yes | Unknown |
+| [Judge0 CE](https://ce.judge0.com/) | 온라인 코드 실행 시스템 | `apiKey` | Yes | Unknown |
+| [KONTESTS](https://kontests.net/api) | 다가오는 및 현재 진행 중인 경쟁 코딩 대회를 위해 | No | Yes | Unknown |
+| [Mintlify](https://docs.mintlify.com) | 코드에 대한 문서를 프로그래밍 방식으로 생성하는 경우 | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 과학 & 수학
 
-|                                      API                                       | 설명                                                                                 |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------------------------------------: | ------------------------------------------------------------------------------------ | :------: | :---: | :-----: |
-|                   [arcsecond.io](https://api.arcsecond.io/)                    | 다중 천문학 데이터 소스                                                             |    No    |  Yes  | Unknown |
-|                    [CORE](https://core.ac.uk/services#api)                     | 세계의 오픈 액세스 연구 논문에 액세스                                               | `apiKey` |  Yes  | Unknown |
-|                        [GBIF](http://api.gbif.org/v1/)                         | 세계 생물다양성 정보 기구                                                            |    No    |  Yes  |   Yes   |
-|         [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki)          | 전 세계 조직의 수백만 박물관 표본에 액세스                                           |    No    |  Yes  | Unknown |
-|                [ITIS](https://www.itis.gov/ws_description.html)                | 통합 분류 정보 시스템                                                               |    No    |  Yes  | Unknown |
-|         [Launch Library](https://launchlibrary.net/docs/1.3/api.html)          | 예정된 우주 발사                                                                     |    No    |  Yes  | Unknown |
-|               [Minor Planet Center](http://www.asterank.com/mpc)               | Asterank.com 정보                                                                    |    No    |  No   | Unknown |
-|                          [NASA](https://api.nasa.gov)                          | 이미지를 포함한 NASA 데이터                                                          |    No    |  Yes  | Unknown |
-|                        [Newton](https://newton.now.sh/)                        | 기호 및 산술 수학 계산기                                                             |    No    |  Yes  | Unknown |
-|                   [Numbers](https://math.tools/api/numbers/)                   | 오늘의 숫자, 랜덤 숫자 생성, 숫자 팩트 및 숫자로 하고 싶은 모든 것                   | `apiKey` |  Yes  |   Yes   |
-|                        [Numbers](http://numbersapi.com)                        | 숫자에 대한 팩트                                                                     |    No    |  No   | Unknown |
-|             [Open Notify](http://open-notify.org/Open-Notify-API/)             | ISS 우주비행사, 현재 위치 등                                                         |    No    |  No   | Unknown |
-|               [Open Science Framework](https://developer.osf.io)               | 연구 설계, 연구 자료, 데이터, 원고 등을 위한 저장소 및 아카이브                      |    No    |  Yes  | Unknown |
-|                     [SHARE](https://share.osf.io/api/v2/)                      | 연구 및 학술 활동에 대한 무료 공개 데이터셋                                          |    No    |  Yes  | Unknown |
-|                [SpaceX](https://github.com/r-spacex/SpaceX-API)                | 회사, 차량, 발사대 및 발사 데이터                                                    |    No    |  Yes  | Unknown |
-|              [Sunrise and Sunset](https://sunrise-sunset.org/api)              | 주어진 위도와 경도에 대한 일몰 및 일출 시간                                          |    No    |  Yes  | Unknown |
-|            [Unusual Units Converter](https://api.unusualunits.com/)            | 표준 및 비표준 단위를 위한 단위 변환기                                               |    No    |  Yes  |   Yes   |
-| [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | 실시간 지진 데이터                                                                   |    No    |  Yes  | Unknown |
-|             [USGS Water Services](https://waterservices.usgs.gov/)             | 강과 호수의 수질 및 수위 정보                                                        |    No    |  Yes  | Unknown |
-|  [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589)  | 세계 데이터                                                                          |    No    |  No   | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [arcsecond.io](https://api.arcsecond.io/) | 다중 천문학 데이터 소스 | No | Yes | Unknown |
+| [arXiv](https://arxiv.org/help/api/user-manual) | 선별된 연구 공유 플랫폼: 물리학, 수학, 양적 금융, 경제학 | No | Yes | Unknown |
+| [CodeCogs](https://editor.codecogs.com/docs/4-LaTeX_rendering.php) | 스타일 옵션을 사용하여 PNG, GIF, SVG, EMF, PDF, JSON 또는 다운로드 형식으로 LaTeX 방정식을 렌더링합니다. | No | Yes | Unknown |
+| [CORE](https://core.ac.uk/services#api) | 세계의 오픈 액세스 연구 논문에 액세스 | `apiKey` | Yes | Unknown |
+| [GBIF](https://www.gbif.org/developer/summary) | 지구생물다양성정보시설 | No | Yes | Yes |
+| [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | 전 세계 조직의 수백만 박물관 표본에 액세스 | No | Yes | Unknown |
+| [inspirehep.net](https://github.com/inspirehep/rest-api-doc) | 고에너지 물리학 정보. 체계 | No | Yes | Unknown |
+| [isEven (humor)](https://isevenapi.xyz/) | 숫자가 짝수인지 확인 | No | Yes | Unknown |
+| [ISRO](https://isro.vercel.app) | ISRO 우주 공예품 정보 | No | Yes | No |
+| [ITIS](https://www.itis.gov/ws_description.html) | 통합 분류 정보 시스템 | No | Yes | Unknown |
+| [Launch Library 2](https://thespacedevs.com/llapi) | 우주 비행 발사 및 이벤트 데이터베이스 | No | Yes | Yes |
+| [Materials Platform for Data Science](https://mpds.io) | 재료과학을 위한 엄선된 실험 데이터 | `apiKey` | Yes | No |
+| [Minor Planet Center](http://www.asterank.com/mpc) | Asterank.com 정보 | No | No | Unknown |
+| [NASA](https://api.nasa.gov) | 이미지를 포함한 NASA 데이터 | No | Yes | No |
+| [NASA ADS](https://ui.adsabs.harvard.edu/help/api/api-docs.html) | NASA 천체 물리학 데이터 시스템 | `OAuth` | Yes | Yes |
+| [Newton](https://newton.vercel.app) | 기호 및 산술 수학 계산기 | No | Yes | No |
+| [Noctua](https://api.noctuasky.com/api/v1/swaggerdoc/) | NoctuaSky 기능에 액세스하는 데 사용되는 REST API | No | Yes | Unknown |
+| [Numbers](https://math.tools/api/numbers/) | 오늘의 숫자, 랜덤 숫자 생성, 숫자 팩트 및 숫자로 하고 싶은 모든 것 | `apiKey` | Yes | No |
+| [Numbers](http://numbersapi.com) | 숫자에 대한 팩트 | No | No | No |
+| [Ocean Facts](https://oceanfacts.herokuapp.com/) | 해양학의 물리과학에 관한 사실 | No | Yes | Unknown |
+| [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS 우주비행사, 현재 위치 등 | No | No | No |
+| [Open Science Framework](https://developer.osf.io) | 연구 설계, 연구 자료, 데이터, 원고 등을 위한 저장소 및 아카이브 | No | Yes | Unknown |
+| [OpenAlex](https://docs.openalex.org/) | 학술 저작물, 저자, 기관, 출처 및 개념이 포함된 공개 카탈로그 | No | Yes | Yes |
+| [Purple Air](https://www2.purpleair.com/) | 실시간 대기질 모니터링 | No | Yes | Unknown |
+| [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | base64 인코딩을 디코딩하고 구문 분석하여 JSON의 계산에 대한 솔루션을 반환합니다. | No | Yes | Yes |
+| [SHARE](https://share.osf.io/api/v2/) | 연구 및 학술 활동에 대한 무료 공개 데이터셋 | No | Yes | No |
+| [SpaceX](https://github.com/r-spacex/SpaceX-API) | 회사, 차량, 발사대 및 발사 데이터 | No | Yes | No |
+| [SpaceX](https://api.spacex.land/graphql/) | GraphQL, 회사, 선박, 런치패드 및 런치 데이터 | No | Yes | Unknown |
+| [Sunrise and Sunset](https://sunrise-sunset.org/api) | 주어진 위도와 경도에 대한 일몰 및 일출 시간 | No | Yes | No |
+| [Times Adder](https://github.com/FranP-code/API-Times-Adder) | 이 API를 사용하면 전송된 배열에 도입된 각 시간을 추가할 수 있습니다. | No | Yes | No |
+| [TLE](https://tle.ivanstanojevic.me/#/docs) | 위성정보 | No | Yes | No |
+| [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | 실시간 지진 데이터 | No | Yes | No |
+| [USGS Water Services](https://waterservices.usgs.gov/) | 강과 호수의 수질 및 수위 정보 | No | Yes | No |
+| [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589) | 세계 데이터 | No | Yes | No |
+| [xMath](https://x-math.herokuapp.com/) | 무작위 수학적 표현 | No | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 보안
 
-|                                             API                                             | 설명                                                                                                        |   인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------------------------------------------: | ----------------------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                             [Censys.io](https://censys.io/api)                              | 인터넷에 연결된 호스트 및 기기를 위한 검색 엔진                                                             | `apiKey` |  Yes  |   No    |
-|                         [CRXcavator](https://crxcavator.io/apidocs)                         | Chrome 확장 프로그램 위험 점수                                                                              | `apiKey` |  Yes  | Unknown |
-|                              [FishFish](https://fishfish.gg/)                               | Discord 전반의 안전성을 향상시키는 리소스와 서비스 제공에 중점을 둔 자원봉사 사이버보안 프로젝트            |    No    |  Yes  | Unknown |
-|                     [HaveIBeenPwned](https://haveibeenpwned.com/API/v3)                     | 이전에 데이터 침해에서 노출된 비밀번호                                                                      | `apiKey` |  Yes  | Unknown |
-| [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | 미국 국가 취약점 데이터베이스                                                                               |    No    |  Yes  | Unknown |
-|                         [phish.directory](https://phish.directory/)                         | 피싱 링크 및 시도를 포착, 방지, 분류하는 커뮤니티 기반 안티 피싱 도구를 위한 API                           | `apiKey` |  Yes  | Unknown |
-|                     [Secrets-APi](https://secrets-api.appbrewery.com/)                      | 학습 목적으로 사용, 이 API로 모든 보안 유형 학습                                                           |   All    |  Yes  | Unkown  |
-|                    [SecurityTrails](https://securitytrails.com/corp/api)                    | 현재 및 과거 WHOIS 및 DNS 레코드와 같은 도메인 및 IP 관련 정보                                             | `apiKey` |  Yes  | Unknown |
-|                           [Shodan](https://developer.shodan.io/)                            | 인터넷에 연결된 기기를 위한 검색 엔진                                                                       | `apiKey` |  Yes  | Unknown |
-|                          [UK Police](https://data.police.uk/docs/)                          | 영국 경찰 데이터                                                                                            |    No    |  Yes  | Unknown |
-|                           [Whoisfreaks](https://whoisfreaks.com/)                           | 향상된 보안을 위한 포괄적인 위협 인텔리전스 및 공격 표면 분석 기능을 조직에 제공하는 도메인 및 DNS 관련 정보 | `apiKey` |  Yes  |   No    |
-|                          [WhoisJSONApi](https://whoisjsonapi.com/)                          | 온라인 위협을 탐지하고 방지하여 개인과 조직의 전반적인 온라인 안전성을 향상시키는 도메인 WHOIS 정보        | `apiKey` |  Yes  |   No    |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Application Environment Verification](https://github.com/fingerprintjs/aev) | 사용자 장치의 안전을 확인하고 루팅된 장치 및 기타 위험을 감지하는 Android 라이브러리 및 API | `apiKey` | Yes | Yes |
+| [BinaryEdge](https://docs.binaryedge.io/api-v2.html) | BinaryEdge 40fy 스캐닝 플랫폼에 대한 액세스 제공 | `apiKey` | Yes | Yes |
+| [BitWarden](https://bitwarden.com/help/api/) | 최고의 오픈소스 비밀번호 관리자 | `OAuth` | Yes | Unknown |
+| [Botd](https://github.com/fingerprintjs/botd) | Botd는 JavaScript 봇 감지를 위한 브라우저 라이브러리입니다. | `apiKey` | Yes | Yes |
+| [Bugcrowd](https://docs.bugcrowd.com/api/getting-started/) | 보고된 문제를 프로그래밍 방식으로 상호작용하고 추적하기 위한 Bugcrowd API | `apiKey` | Yes | Unknown |
+| [Censys](https://search.censys.io/api) | 인터넷에 연결된 호스트 및 장치에 대한 검색 엔진 | `apiKey` | Yes | No |
+| [Classify](https://classify-web.herokuapp.com/#/api) | 문자 메시지 암호화 및 복호화 | No | Yes | Yes |
+| [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | 미국 전역과 퓨레토리코의 범죄자 데이터를 제공합니다. | `apiKey` | Yes | Yes |
+| [CRXcavator](https://crxcavator.io/apidocs) | Chrome 확장 프로그램 위험 점수 | `apiKey` | Yes | Unknown |
+| [Dehash.lt](https://github.com/Dehash-lt/api) | 해시 복호화 MD5, SHA1, SHA3, SHA256, SHA384, SHA512 | No | Yes | Unknown |
+| [EmailRep](https://docs.emailrep.io/) | 이메일 주소 위협 및 위험 예측 | No | Yes | Unknown |
+| [Escape](https://github.com/polarspetroll/EscapeAPI) | 다양한 종류의 쿼리를 이스케이프하기 위한 API | No | Yes | No |
+| [FilterLists](https://filterlists.com) | 광고 차단기 및 방화벽용 필터 목록 | No | Yes | Unknown |
+| [FingerprintJS Pro](https://dev.fingerprintjs.com/docs) | 매우 정확한 브라우저 지문 인식을 제공하는 사기 탐지 API | `apiKey` | Yes | Yes |
+| [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order) | AI를 사용하여 사기를 탐지하는 주문 정보 심사 | `apiKey` | Yes | Unknown |
+| [FullHunt](https://api-docs.fullhunt.io/#introduction) | 전체 인터넷의 검색 가능한 공격 표면 데이터베이스 | `apiKey` | Yes | Unknown |
+| [GitGuardian](https://api.gitguardian.com/doc) | 파일에서 비밀(API 키, 데이터베이스 자격 증명) 검사 | `apiKey` | Yes | No |
+| [GreyNoise](https://docs.greynoise.io/reference/get_v3-community-ip) | GreyNoise 데이터 세트에서 IP를 쿼리하고 전체 IP 컨텍스트 데이터의 하위 집합을 검색합니다. | `apiKey` | Yes | Unknown |
+| [HackerOne](https://api.hackerone.com/) | 창의적인 버그 현상금 사냥을 위해 생산성을 높이는 데 도움이 되는 업계 최초의 해커 API | `apiKey` | Yes | Unknown |
+| [Hashable](https://hashable.space/pages/api/) | 높은 수준의 암호화 기능 및 방법에 액세스하기 위한 REST API | No | Yes | Yes |
+| [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | 이전에 데이터 침해에서 노출된 비밀번호 | `apiKey` | Yes | Unknown |
+| [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Intelligence X를 통해 OSINT 수행 | `apiKey` | Yes | Unknown |
+| [IPLogs](https://iplogs.com/docs) | 무료 VPN, 프록시, Tor 및 데이터 센터 IP 감지. 13개 소스, 활성 프로빙. | No | Yes | Yes |
+| [LoginRadius](https://www.loginradius.com/docs/) | 관리형 사용자 인증 서비스 | `apiKey` | Yes | Yes |
+| [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | MSRC(Microsoft 보안 대응 센터)와 협력하기 위한 프로그래밍 방식 인터페이스 | No | Yes | Unknown |
+| [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla 천문대 http 스캐너 | No | Yes | Unknown |
+| [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints) | Mozilla 천문대 TLS 스캐너 | No | Yes | Unknown |
+| [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | 미국 국가 취약점 데이터베이스 | No | Yes | Unknown |
+| [Passwordinator](https://github.com/fawazsullia/password-generator/) | 다양한 복잡성의 무작위 비밀번호 생성 | No | Yes | Yes |
+| [PhishStats](https://phishstats.info/) | 피싱 데이터베이스 | No | Yes | Unknown |
+| [Privacy.com](https://privacy.com/developer/docs) | 은행에 다시 연결되는 판매자별 일회용 신용카드 번호를 생성하세요. | `apiKey` | Yes | Unknown |
+| [Pulsedive](https://pulsedive.com/api/) | 위협 인텔리전스 데이터를 실시간으로 스캔, 검색 및 수집 | `apiKey` | Yes | Unknown |
+| [SecurityTrails](https://securitytrails.com/corp/apidocs) | 현재 및 과거 WHOIS, DNS 레코드 등 도메인 및 IP 관련 정보 | `apiKey` | Yes | Unknown |
+| [Shodan](https://developer.shodan.io/) | 인터넷에 연결된 기기를 위한 검색 엔진 | `apiKey` | Yes | Unknown |
+| [Spyse](https://spyse-dev.readme.io/reference/quick-start) | 모든 인터넷 자산의 데이터에 액세스하고 강력한 공격 표면 관리 애플리케이션 구축 | `apiKey` | Yes | Unknown |
+| [Threat Jammer](https://threatjammer.com/docs/index) | 엄선된 위협 인텔리전스 데이터를 통한 위험 평가 서비스 | `apiKey` | Yes | Unknown |
+| [UK Police](https://data.police.uk/docs/) | 영국 경찰 데이터 | No | Yes | Unknown |
+| [Virushee](https://api.virushee.com/) | Virushee 파일/데이터 스캔 | No | Yes | Yes |
+| [VulDB](https://vuldb.com/?doc.api) | VulDB API를 사용하면 트랜잭션 봇과 함께 하나 이상의 항목에 대한 쿼리를 시작할 수 있습니다. | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 쇼핑
 
-|                                  API                                  | 설명                                                          |   인증   | HTTPS |  CORS   |
-| :-------------------------------------------------------------------: | ------------------------------------------------------------- | :------: | :---: | :-----: |
-| [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | 제품, 구매 옵션, 카테고리, 추천, 매장 및 상거래              | `apiKey` |  Yes  | Unknown |
-|            [Bratabase](https://developers.bratabase.com/)             | 다양한 브래지어 사이즈 데이터베이스                           | `OAuth`  |  Yes  | Unknown |
-|                [eBay](https://go.developer.ebay.com/)                 | eBay에서 판매 및 구매                                         | `OAuth`  |  Yes  | Unknown |
-|                   [Wegmans](https://dev.wegmans.io)                   | Wegmans 푸드 마켓                                             | `apiKey` |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | 제품, 구매 옵션, 카테고리, 추천, 매장 및 상거래 | `apiKey` | Yes | Unknown |
+| [Digi-Key](https://www.digikey.com/en/resources/api-solutions) | 전자 부품의 가격 및 재고 검색 및 주문 | `OAuth` | Yes | Unknown |
+| [Dummy Products](https://dummyproducts-api.herokuapp.com/) | 자리표시자 이미지가 포함된 더미 전자상거래 제품 JSON 데이터를 가져오는 API | `apiKey` | Yes | Yes |
+| [eBay](https://developer.ebay.com/) | eBay에서 판매 및 구매 | `OAuth` | Yes | Unknown |
+| [Etsy](https://www.etsy.com/developers/documentation/getting_started/api_basics) | 매장을 관리하고 목록과 상호 작용 | `OAuth` | Yes | Unknown |
+| [Flipkart Marketplace](https://seller.flipkart.com/api-docs/FMSAPI.html) | Flipkart 마켓플레이스에서 상품 목록 관리, 주문 이행 | `OAuth` | Yes | Yes |
+| [Lazada](https://open.lazada.com/doc/doc.htm) | 제품 평가 및 판매자 성과 지표 검색 | `apiKey` | Yes | Unknown |
+| [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es) | 판매, 광고, 제품, 서비스 및 상점 관리 | `apiKey` | Yes | Unknown |
+| [Octopart](https://octopart.com/api/v4/reference) | 제조, 설계, 소싱을 위한 전자부품 데이터 | `apiKey` | Yes | Unknown |
+| [OLX Poland](https://developer.olx.pl/api/doc#section/) | 광고 게시, 관리, OLX 사용자와의 커뮤니케이션을 통해 현지 사이트와 통합 | `apiKey` | Yes | Unknown |
+| [Rappi](https://dev-portal.rappi.com/) | Rappi 앱에서 주문을 관리하세요 | `OAuth` | Yes | Unknown |
+| [Shopee](https://open.shopee.com/documents?version=1) | Shopee의 다양한 서비스 통합을 위한 Shopee의 공식 API | `apiKey` | Yes | Unknown |
+| [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia의 다양한 서비스 통합을 위한 Tokopedia의 공식 API | `OAuth` | Yes | Unknown |
+| [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/) | WordPress 웹 사이트에서 JSON 형식으로 데이터를 생성, 읽기, 업데이트 및 삭제하는 WooCommerce REST APIS | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 소셜
 
-|                                  API                                   | 설명                                                                             |   인증   | HTTPS |  CORS   |
-| :--------------------------------------------------------------------: | -------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|              [Buffer](https://buffer.com/developers/api)               | Buffer의 대기 중이거나 전송된 업데이트에 액세스                                  | `OAuth`  |  Yes  | Unknown |
-|            [Cisco Spark](https://developer.ciscospark.com)             | 팀 협업 소프트웨어                                                               | `OAuth`  |  Yes  | Unknown |
-|        [Discord](https://discordapp.com/developers/docs/intro)         | Discord용 봇 만들기, Discord를 외부 플랫폼에 통합                                | `OAuth`  |  Yes  | Unknown |
-|              [Disqus](https://disqus.com/api/docs/auth/)               | Disqus 데이터와 소통                                                             | `OAuth`  |  Yes  | Unknown |
-|              [Facebook](https://developers.facebook.com/)              | Facebook 로그인, FB에서 공유, 소셜 플러그인, 분석 등                             | `OAuth`  |  Yes  | Unknown |
-|            [Foursquare](https://developer.foursquare.com/)             | Foursquare 사용자 및 장소와 상호작용 (지리위치 기반 체크인, 사진, 팁, 이벤트 등) | `OAuth`  |  Yes  | Unknown |
-|      [Full Contact](https://www.fullcontact.com/developer/docs/)       | 소셜 미디어 프로필 및 연락처 정보 가져오기                                       | `OAuth`  |  Yes  | Unknown |
-|            [HackerNews](https://github.com/HackerNews/API)             | CS 및 기업가정신을 위한 소셜 뉴스                                                |    No    |  Yes  | Unknown |
-|           [Instagram](https://www.instagram.com/developer/)            | Instagram 로그인, Instagram에서 공유, 소셜 플러그인 등                           | `OAuth`  |  Yes  | Unknown |
-|            [Meetup.com](https://www.meetup.com/meetup_api/)            | Meetup.com의 밋업 데이터                                                         | `apiKey` |  Yes  | Unknown |
-|                 [MySocialApp](https://mysocialapp.io)                  | 모든 앱에 원활한 소셜 네트워킹 기능, API, SDK                                    | `apiKey` |  Yes  | Unknown |
-| [Open Collective](https://docs.opencollective.com/help/developers/api) | Open Collective 데이터 가져오기                                                  |    No    |  Yes  | Unknown |
-|             [Pinterest](https://developers.pinterest.com/)             | 아이디어의 세계 카탈로그                                                         | `OAuth`  |  Yes  | Unknown |
-|               [PWRTelegram bot](https://pwrtelegram.xyz)               | Telegram 봇 API의 부스트된 버전                                                  | `apiKey` |  Yes  | Unknown |
-|                [Reddit](https://www.reddit.com/dev/api)                | 인터넷의 홈페이지                                                                | `OAuth`  |  Yes  | Unknown |
-|               [SocialData API](https://socialdata.tools)               | Twitter 데이터를 읽는 비공식 API                                                 | `apiKey` |  Yes  |   No    |
-|                    [Slack](https://api.slack.com/)                     | 팀 인스턴트 메시징                                                               | `OAuth`  |  Yes  | Unknown |
-|           [Telegram Bot](https://core.telegram.org/bots/api)           | 봇을 위한 간소화된 HTTP 버전의 MTProto API                                       | `OAuth`  |  Yes  | Unknown |
-|   [Telegram MTProto](https://core.telegram.org/api#getting-started)    | Telegram 데이터 읽기 및 쓰기                                                     | `apiKey` |  Yes  | Unknown |
-|          [Trash Nothing](https://trashnothing.com/developer)           | 매일 수천 개의 무료 아이템이 게시되는 프리사이클링 커뮤니티                      | `OAuth`  |  Yes  |   Yes   |
-|            [Tumblr](https://www.tumblr.com/docs/en/api/v2)             | Tumblr 데이터 읽기 및 쓰기                                                       | `OAuth`  |  Yes  | Unknown |
-|                  [Twitch](https://dev.twitch.tv/docs)                  | 게임 스트리밍 API                                                                | `OAuth`  |  Yes  | Unknown |
-|            [Twitter](https://developer.twitter.com/en/docs)            | Twitter 데이터 읽기 및 쓰기                                                      | `OAuth`  |  Yes  |   No    |
-|                     [vk](https://vk.com/dev/sites)                     | vk 데이터 읽기 및 쓰기                                                           | `OAuth`  |  Yes  | Unknown |
-|              [SharedCount](http://docs.sharedcount.com/)               | Pinterest 및 Facebook 공유 추적                                                 | `apiKey` |  Yes  | Unknown |
-|                  [TwitterApi](http://twitterapi.io/)                   | 대량 Twitter 데이터 읽기 API                                                    | `apiKey` |  Yes  |   No    |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [4chan](https://github.com/4chan/4chan-API) | 다양한 주제를 다루는 심플한 이미지 기반의 게시판 | No | Yes | Yes |
+| [Ayrshare](https://www.ayrshare.com) | 여러 사용자의 소셜 미디어 계정을 게시하고, 분석하고, 관리하기 위한 소셜 미디어 API | `apiKey` | Yes | Yes |
+| [aztro](https://aztro.sameerkumar.website/) | 어제, 오늘, 내일의 일일 운세 정보 | No | Yes | Unknown |
+| [Blogger](https://developers.google.com/blogger/) | Blogger API를 사용하면 클라이언트 응용프로그램에서 Blogger 콘텐츠를 보고 업데이트할 수 있습니다. | `OAuth` | Yes | Unknown |
+| [Bluesky](https://docs.bsky.app/) | AT 프로토콜을 통한 분산형 소셜 네트워킹 | No | Yes | Yes |
+| [Cisco Spark](https://developer.ciscospark.com) | 팀 협업 소프트웨어 | `OAuth` | Yes | Unknown |
+| [Dangerous Discord Database](https://discord.riverside.rocks/docs/index.php) | 악성 Discord 계정 데이터베이스 | `apiKey` | Yes | Unknown |
+| [Discord](https://discord.com/developers/docs/intro) | Discord용 봇을 만들고 Discord를 외부 플랫폼에 통합하세요 | `OAuth` | Yes | Unknown |
+| [Disqus](https://disqus.com/api/docs/auth/) | Disqus 데이터와 소통 | `OAuth` | Yes | Unknown |
+| [Doge-Meme](https://api.doge-meme.lol/docs) | 'Meme' 감각이 포함된 r/dogecoin의 인기 밈 게시물 | No | Yes | Yes |
+| [Facebook](https://developers.facebook.com/) | Facebook 로그인, FB에서 공유, 소셜 플러그인, 분석 등 | `OAuth` | Yes | Unknown |
+| [Foursquare](https://developer.foursquare.com/) | Foursquare 사용자 및 장소와 상호작용 (지리위치 기반 체크인, 사진, 팁, 이벤트 등) | `OAuth` | Yes | Unknown |
+| [Fuck Off as a Service](https://www.foaas.com) | 누군가에게 꺼져달라고 요청합니다 | No | Yes | Unknown |
+| [Full Contact](https://docs.fullcontact.com/) | 소셜 미디어 프로필 및 연락처 정보 얻기 | `OAuth` | Yes | Unknown |
+| [HackerNews](https://github.com/HackerNews/API) | CS 및 기업가정신을 위한 소셜 뉴스 | No | Yes | Unknown |
+| [Hashnode](https://hashnode.com) | 개발자를 위해 구축된 블로그 플랫폼 | No | Yes | Unknown |
+| [Instagram](https://www.instagram.com/developer/) | Instagram 로그인, Instagram에서 공유, 소셜 플러그인 등 | `OAuth` | Yes | Unknown |
+| [Kakao](https://developers.kakao.com/) | 카카오 로그인, 카카오톡 공유, 소셜 플러그인 등 | `OAuth` | Yes | Unknown |
+| [Lanyard](https://github.com/Phineas/lanyard) | HTTP REST API 또는 WebSocket을 통해 Discord에서 귀하의 현재 상태를 검색하세요 | No | Yes | Yes |
+| [Line](https://developers.line.biz/) | 라인 로그인, 라인에서 공유, 소셜 플러그인 등 | `OAuth` | Yes | Unknown |
+| [LinkedIn](https://docs.microsoft.com/en-us/linkedin/?context=linkedin/context) | LinkedIn과의 모든 디지털 통합의 기초 | `OAuth` | Yes | Unknown |
+| [Meetup.com](https://www.meetup.com/api/guide) | Meetup.com의 Meetup 관련 데이터 | `apiKey` | Yes | Unknown |
+| [Microsoft Graph](https://docs.microsoft.com/en-us/graph/api/overview) | Microsoft 365, Windows 10 및 Enterprise Mobility의 데이터와 인텔리전스에 액세스하세요. | `OAuth` | Yes | Unknown |
+| [NAVER](https://developers.naver.com/main/) | 네이버 로그인, 네이버에 공유, 소셜 플러그인 등 | `OAuth` | Yes | Unknown |
+| [Open Collective](https://docs.opencollective.com/help/developers/api) | Open Collective 데이터 가져오기 | No | Yes | Unknown |
+| [Pinterest](https://developers.pinterest.com/) | 아이디어의 세계 카탈로그 | `OAuth` | Yes | Unknown |
+| [Product Hunt](https://api.producthunt.com/v2/docs) | 기술 분야 최고의 신제품 | `OAuth` | Yes | Unknown |
+| [Reddit](https://www.reddit.com/dev/api) | 인터넷의 홈페이지 | `OAuth` | Yes | Unknown |
+| [Revolt](https://developers.revolt.chat/api/) | Revolt 오픈 소스 Discord 대안 | `apiKey` | Yes | Unknown |
+| [Saidit](https://www.saidit.net/dev/api) | 오픈 소스 Reddit 클론 | `OAuth` | Yes | Unknown |
+| [Slack](https://api.slack.com/) | 팀 인스턴트 메시징 | `OAuth` | Yes | Unknown |
+| [TamTam](https://dev.tamtam.chat/) | TamTam과 상호작용하는 Bot API | `apiKey` | Yes | Unknown |
+| [Telegram Bot](https://core.telegram.org/bots/api) | 봇을 위한 간소화된 HTTP 버전의 MTProto API | `apiKey` | Yes | Unknown |
+| [Telegram MTProto](https://core.telegram.org/api#getting-started) | Telegram 데이터 읽기 및 쓰기 | `OAuth` | Yes | Unknown |
+| [Telegraph](https://telegra.ph/api) | 매력적인 블로그를 쉽게 만들고 공유하세요 | `apiKey` | Yes | Unknown |
+| [TikTok](https://developers.tiktok.com/doc/login-kit-web) | TikTok 플랫폼에서 사용자 정보 및 사용자의 비디오 게시물을 가져옵니다. | `OAuth` | Yes | Unknown |
+| [Trash Nothing](https://trashnothing.com/developer) | 매일 수천 개의 무료 아이템이 게시되는 프리사이클링 커뮤니티 | `OAuth` | Yes | Yes |
+| [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Tumblr 데이터 읽기 및 쓰기 | `OAuth` | Yes | Unknown |
+| [Twitch](https://dev.twitch.tv/docs) | 게임 스트리밍 API | `OAuth` | Yes | Unknown |
+| [Twitter](https://developer.twitter.com/en/docs) | Twitter 데이터 읽기 및 쓰기 | `OAuth` | Yes | No |
+| [vk](https://vk.com/dev/sites) | vk 데이터 읽기 및 쓰기 | `OAuth` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 스포츠 & 피트니스
 
-|                                  API                                  | 설명                                                                       |      인증       | HTTPS |  CORS   |
-| :-------------------------------------------------------------------: | -------------------------------------------------------------------------- | :-------------: | :---: | :-----: |
-|                 [balldontlie](https://balldontlie.io)                 | NBA 통계 데이터에 대한 액세스 제공                                         |       No        |  Yes  |   Yes   |
-|       [BikeWise](https://www.bikewise.org/documentation/api_v2)       | 자전거 사고, 위험 및 도난에 대해 배우고 신고하는 곳                        |       No        |  Yes  | Unknown |
-|         [Canadian Football League (CFL)](http://api.cfl.ca/)          | CFL에 대한 실시간 리그, 팀 및 선수 통계를 제공하는 공식 JSON API           |    `apiKey`     |  Yes  |   No    |
-|        [Cartola FC](https://github.com/wgenial/cartrolandofc)         | 팀의 부분 점수를 확인하는 Cartola FC API                                   |       No        |  Yes  | Unknown |
-|                [City Bikes](http://api.citybik.es/v2/)                | 전 세계 도시 자전거                                                        |       No        |  No   | Unknown |
-|                  [Ergast F1](http://ergast.com/mrd/)                  | 1950년 세계 챔피언십 시작부터의 F1 데이터                                  |       No        |  Yes  | Unknown |
-|                      [F1 API](https://f1api.dev)                      | 자체 NPM 패키지와 함께 실시간 무료 F1 데이터                               |       No        |  Yes  | Unknown |
-|        [F1 Data API](https://github.com/Jacobbrewer1/f1-data)         | 1950년부터의 F1 아카이브 데이터를 제공하는 포뮬러 1 데이터 API             |       No        |  Yes  |   No    |
-|                   [Fitbit](https://dev.fitbit.com/)                   | Fitbit 정보                                                                |     `OAuth`     |  Yes  | Unknown |
-|    [Football (Soccer) Videos](https://www.scorebat.com/video-api/)    | 프리미어리그, 분데스리가, 세리에 A 등의 골과 하이라이트 임베드 코드        |       No        |  Yes  |   Yes   |
-|      [Football Prediction](https://boggio-analytics.com/fp-api/)      | 예정된 축구 경기 예측, 배당률, 결과 및 통계                               | `X-Mashape-Key` |  Yes  | Unknown |
-|        [Football-Data.org](http://api.football-data.org/index)        | 축구 데이터                                                                |       No        |  No   | Unknown |
-|      [Golf-Data](https://github.com/Jacobbrewer1/golf-data-docs)      | 골프 코스, 클럽 및 홀 정보가 포함된 골프 데이터 API                        |       No        |  Yes  |   No    |
-|           [JCDecaux Bike](https://developer.jcdecaux.com/)            | JCDecaux 셀프 서비스 자전거                                                |    `apiKey`     |  Yes  | Unknown |
-| [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | 현재 및 과거 NBA 통계                                                      |       No        |  Yes  | Unknown |
-|       [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)       | NHL 과거 데이터 및 통계                                                    |       No        |  Yes  | Unknown |
-|                [Strava](https://strava.github.io/api/)                | 운동선수, 활동 등과 연결                                                   |     `OAuth`     |  Yes  | Unknown |
-|                [SuredBits](https://suredbits.com/api/)                | 팀, 선수, 게임, 점수 및 통계를 포함한 스포츠 데이터 쿼리                   |       No        |  No   |   No    |
-|          [TheSportsDB](https://www.thesportsdb.com/api.php)           | 크라우드소싱 스포츠 데이터 및 아트워크                                     |    `apiKey`     |  Yes  |   Yes   |
-|                [Wger](https://wger.de/en/software/api)                | 운동, 근육 또는 장비로서의 운동 관리자 데이터                              |    `apiKey`     |  Yes  | Unknown |
-|                 [CricData](https://cricketdata.org/)                  | 최고의 크리켓 데이터 API - 점수, 스코어카드, 선수 데이터, 판타지 API       |    `apiKey`     |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [API-FOOTBALL](https://www.api-football.com/documentation-v3) | 풋볼 리그 및 컵에 대한 정보를 얻으세요 | `apiKey` | Yes | Yes |
+| [ApiMedic](https://apimedic.com/) | ApiMedic은 주로 환자를 위한 의료 증상 검사기 API를 제공합니다. | `apiKey` | Yes | Unknown |
+| [balldontlie](https://www.balldontlie.io) | Balldontlie는 NBA의 통계 데이터에 대한 액세스를 제공합니다. | No | Yes | Yes |
+| [Canadian Football League (CFL)](http://api.cfl.ca/) | CFL에 대한 실시간 리그, 팀 및 선수 통계를 제공하는 공식 JSON API | `apiKey` | Yes | No |
+| [City Bikes](https://api.citybik.es/v2/) | 전 세계의 도시 자전거 | No | Yes | Unknown |
+| [Cloudbet](https://www.cloudbet.com/api/) | 공식 Cloudbet API는 프로그래밍 방식으로 베팅할 수 있는 실시간 스포츠 배당률과 베팅 API를 제공합니다. | `apiKey` | Yes | Yes |
+| [CollegeFootballData.com](https://collegefootballdata.com) | 비공식 상세 미식축구 통계, 기록, 결과 API | `apiKey` | Yes | Unknown |
+| [DiscGolf](https://discgolfapi.com/docs/) | 구조화된 디스크 골프장 데이터 | No | Yes | Yes |
+| [Ergast F1](http://ergast.com/mrd/) | 1950년 세계 챔피언십 시작부터의 F1 데이터 | No | Yes | Unknown |
+| [Fitbit](https://dev.fitbit.com/) | Fitbit 정보 | `OAuth` | Yes | Unknown |
+| [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | 팀의 통계, 최고 득점자 등을 얻을 수 있는 간단한 오픈 소스 축구 API | `X-Mashape-Key` | Yes | Unknown |
+| [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | 프리미어리그, 분데스리가, 세리에 A 등의 골과 하이라이트 임베드 코드 | No | Yes | Yes |
+| [Football Standings](https://github.com/azharimm/football-standings-api) | epl, la liga, serie a 등 축구 순위를 표시합니다. 데이터는 espn 사이트를 기반으로 합니다. | No | Yes | Yes |
+| [Football-Data](https://www.football-data.org) | 경기 정보, 선수, 팀, 대회가 포함된 축구 데이터 | `X-Mashape-Key` | Yes | Unknown |
+| [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux 셀프 서비스 자전거 | `apiKey` | Yes | Unknown |
+| [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | 현재 및 과거 MLB 통계 | No | No | Unknown |
+| [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | 모든 NBA 통계 데이터, 게임, 라이브스코어, 순위, 통계 | `apiKey` | Yes | Unknown |
+| [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | 현재 및 과거 NBA 통계 | No | Yes | Unknown |
+| [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL 과거 데이터 및 통계 | No | Yes | Unknown |
+| [Oddsmagnet](https://data.oddsmagnet.com) | 여러 영국 북메이커의 배당률 기록 | No | Yes | Yes |
+| [OpenLigaDB](https://www.openligadb.de) | 크라우드 소싱 스포츠 리그 결과 | No | Yes | Yes |
+| [Premier League Standings](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | 모든 현재 프리미어 리그 순위 및 통계 | `apiKey` | Yes | Unknown |
+| [RacingHub](https://racinghub.net/api/v1/docs#/) | Formula 1 과거 데이터 및 통계 | No | Yes | Unknown |
+| [Sport Data](https://sportdataapi.com) | 전 세계의 스포츠 데이터를 받아보세요 | `apiKey` | Yes | Unknown |
+| [Sport List & Data](https://developers.decathlon.com/products/sports) | 스포츠 관련 목록 및 자료 | No | Yes | Yes |
+| [Sport Places](https://developers.decathlon.com/products/sport-places) | 전 세계의 크라우드 소싱 스포츠 장소 | No | Yes | No |
+| [Sport Vision](https://developers.decathlon.com/products/sport-vision) | 이미지에서 스포츠, 브랜드, 장비를 식별하세요. 이미지 스포츠 캡션도 제공됩니다. | `apiKey` | Yes | Yes |
+| [Sportmonks Cricket](https://docs.sportmonks.com/cricket/) | 실시간 크리켓 점수, 플레이어 통계 및 판타지 API | `apiKey` | Yes | Unknown |
+| [Sportmonks Football](https://docs.sportmonks.com/football/) | 축구 점수/일정, 뉴스 API, TV 채널, 통계, 기록, 디스플레이 상태(예: epl, 라 리가 | `apiKey` | Yes | Unknown |
+| [Squiggle](https://api.squiggle.com.au) | 호주 풋볼 리그 경기 일정, 결과 및 예측 | No | Yes | Yes |
+| [Strava](https://strava.github.io/api/) | 운동선수, 활동 등과 연결 | `OAuth` | Yes | Unknown |
+| [SuredBits](https://suredbits.com/api/) | 팀, 선수, 게임, 점수 및 통계를 포함한 스포츠 데이터 쿼리 | No | No | No |
+| [TheSportsDB](https://www.thesportsdb.com/api.php) | 크라우드소싱 스포츠 데이터 및 아트워크 | `apiKey` | Yes | Yes |
+| [Tredict](https://www.tredict.com/blog/oauth_docs/) | 활동, 건강 데이터 등을 가져오고 설정하세요. | `OAuth` | Yes | Unknown |
+| [Wger](https://wger.de/en/software/api) | 운동, 근육 또는 장비로서의 운동 관리자 데이터 | `apiKey` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 테스트 데이터
 
-|                                      API                                      | 설명                                                     |   인증   | HTTPS |  CORS   |
-| :---------------------------------------------------------------------------: | -------------------------------------------------------- | :------: | :---: | :-----: |
-|                [Bacon Ipsum](https://baconipsum.com/json-api/)                | 더 고기가 많은 Lorem Ipsum 생성기                        |    No    |  Yes  | Unknown |
-| [Beeceptor's CRUD APIs](https://beeceptor.com/crud-api/?ref=public-api-lists) | 무료 상태 저장 CRUD API                                  |    No    |  Yes  |   Yes   |
-|               [Dicebear Avatars](https://avatars.dicebear.com/)               | 랜덤 픽셀 아트 아바타 생성                               |    No    |  Yes  |   No    |
-|                       [FakeJSON](https://fakejson.com)                        | 테스트 및 가짜 데이터를 생성하는 서비스                  | `apiKey` |  Yes  |   Yes   |
-|                      [JSONing](https://jsoning.com/api/)                      | 프로토타이핑을 위한 모의 데이터                          |    No    |  Yes  |   Yes   |
-|            [JSONPlaceholder](http://jsonplaceholder.typicode.com/)            | 테스트 및 프로토타이핑을 위한 가짜 데이터                |    No    |  No   | Unknown |
-|                      [Lorem API](https://lorem-api.com/)                      | 궁극의 Lorem Ipsum 생성기                                |    No    |  No   | Unknown |
-|                [Micro-Jaymock](https://micro-jaymock.now.sh/)                 | 가짜 JSON 데이터 생성을 위한 작은 API 모킹 마이크로서비스 |    No    |  Yes  |   No    |
-|                         [Mockae](https://mockae.com/)                         | Lua로 구동되는 가짜 REST API                             |    No    |  Yes  |   Yes   |
-|                      [RandomUser](https://randomuser.me)                      | 랜덤 사용자 데이터 생성                                  |    No    |  Yes  | Unknown |
-|                       [RoboHash](https://robohash.org/)                       | 랜덤 로봇/외계인 아바타 생성                             |    No    |  Yes  | Unknown |
-|       [This Person Does not Exist](https://thispersondoesnotexist.com)        | 존재하지 않는 사람들의 실제 얼굴 생성                    |    No    |  Yes  | Unknown |
-|                  [UI Names](https://github.com/thm/uinames)                   | 랜덤 가짜 이름 생성                                      |    No    |  Yes  | Unknown |
-|               [UUID Generator](https://www.uuidtools.com/docs)                | UUID 생성                                                |    No    |  Yes  |   No    |
-|                        [Yes No](https://yesno.wtf/api)                        | 예 또는 아니오를 랜덤으로 생성                           |    No    |  Yes  | Unknown |
-|                [Randommer](https://randommer.io/randommer-api)                | 랜덤 데이터 생성기                                       | `apiKey` |  Yes  |   Yes   |
-|                  [Short Id](https://github.com/aguedo/idgen)                  | 고유한 짧은 ID 생성                                      |    No    |  Yes  |   Yes   |
-|                  [Softwium](https://softwium.com/fake-api/)                   | 테스트 및 프로토타이핑을 위한 테스트 데이터              |    No    |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Bacon Ipsum](https://baconipsum.com/json-api/) | 더 고기가 많은 Lorem Ipsum 생성기 | No | Yes | Unknown |
+| [Dicebear Avatars](https://avatars.dicebear.com/) | 랜덤 픽셀 아트 아바타 생성 | No | Yes | No |
+| [English Random Words](https://random-words-api.vercel.app/word) | 발음으로 영어 무작위 단어 생성 | No | Yes | No |
+| [FakeJSON](https://fakejson.com) | 테스트 및 가짜 데이터를 생성하는 서비스 | `apiKey` | Yes | Yes |
+| [FakerAPI](https://fakerapi.it/en) | 가짜 데이터를 얻기 위한 API 수집 | No | Yes | Yes |
+| [FakeStoreAPI](https://fakestoreapi.com/) | 전자상거래 또는 쇼핑 웹사이트 프로토타입을 위한 가짜 매장 휴식 API | No | Yes | Unknown |
+| [GeneradorDNI](https://api.generadordni.es) | 데이터 생성기 API. 프로필, 차량, 은행 및 카드 등 | `apiKey` | Yes | Unknown |
+| [ItsThisForThat](https://itsthisforthat.com/api.php) | 무작위 시작 아이디어 생성 | No | Yes | No |
+| [JSONPlaceholder](http://jsonplaceholder.typicode.com/) | 테스트 및 프로토타이핑을 위한 가짜 데이터 | No | No | Unknown |
+| [Loripsum](http://loripsum.net/) | 짜증나지 않는 "lorem ipsum" 생성기 | No | No | Unknown |
+| [Mailsac](https://mailsac.com/docs/api) | 일회용 이메일 | `apiKey` | Yes | Unknown |
+| [Metaphorsum](http://metaphorpsum.com/) | 단어와 문장 수를 제공하는 데모 단락 생성 | No | No | Unknown |
+| [Mockaroo](https://www.mockaroo.com/docs) | JSON, CSV, TXT, SQL 및 XML로 가짜 데이터 생성 | `apiKey` | Yes | Unknown |
+| [QuickMocker](https://quickmocker.com) | 상황별, 가짜 또는 무작위 데이터를 생성하는 API 모킹 도구 | No | Yes | Yes |
+| [Random Data](https://random-data-api.com) | 무작위 데이터 생성기 | No | Yes | Unknown |
+| [Randommer](https://randommer.io/randommer-api) | 랜덤 데이터 생성기 | `apiKey` | Yes | Yes |
+| [RandomUser](https://randomuser.me) | 랜덤 사용자 데이터 생성 | No | Yes | Unknown |
+| [RoboHash](https://robohash.org/) | 랜덤 로봇/외계인 아바타 생성 | No | Yes | Unknown |
+| [Spanish random names](https://random-names-api.herokuapp.com/public) | 무작위로 스페인어 이름(성별 포함) 생성 | No | Yes | Unknown |
+| [Spanish random words](https://palabras-aleatorias-public-api.herokuapp.com) | 스페인어 단어를 무작위로 생성 | No | Yes | Unknown |
+| [This Person Does not Exist](https://thispersondoesnotexist.com) | 존재하지 않는 사람들의 실제 얼굴 생성 | No | Yes | Unknown |
+| [Toolcarton](https://testimonialapi.toolcarton.com/) | 무작위 추천 데이터 생성 | No | Yes | Unknown |
+| [UUID Generator](https://www.uuidtools.com/docs) | UUID 생성 | No | Yes | No |
+| [What The Commit](http://whatthecommit.com/index.txt) | 무작위 커밋 메시지 생성기 | No | No | Yes |
+| [Yes No](https://yesno.wtf/api) | 예 또는 아니오를 랜덤으로 생성 | No | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 텍스트 분석
 
-|                                                            API                                                            | 설명                                                                                  |   인증   | HTTPS |  CORS   |
-| :-----------------------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                                      [Aylien Text Analysis](http://docs.aylien.com/)                                      | 정보 검색 및 자연어 API 모음                                                          | `apiKey` |  Yes  | Unknown |
-|                     [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api)                      | 자연어 처리 및 텍스트 분석                                                            | `apiKey` |  Yes  |   Yes   |
-|                                      [Detect Language](https://detectlanguage.com/)                                       | 텍스트 언어 감지                                                                      | `apiKey` |  Yes  | Unknown |
-|                          [Google Cloud Natural](https://cloud.google.com/natural-language/docs/)                          | 감정, 엔티티 및 구문 분석을 포함한 자연어 이해 기술                                   | `apiKey` |  Yes  | Unknown |
-|                        [ParallelDots AI APIs](https://apis.paralleldots.com/text_docs/index.html)                         | 감정 분석, 키워드 추출 및 명명된 엔티티 추출과 같은 텍스트 분석 API 제품군            | `apiKey` |  Yes  |   Yes   |
-|                                       [Semantira](https://semantria.readme.io/docs)                                       | 감정 분석, 분류 및 명명된 엔티티 추출을 포함한 텍스트 분석                            | `OAuth`  |  Yes  | Unknown |
-|                                           [Spam Hunter](https://spam-hunter.ru)                                           | ML을 사용하여 스팸으로 텍스트를 분류하는 무료 서비스                                  | `apiKey` |  Yes  |   Yes   |
-| [Watson Natural Language Understanding](https://www.ibm.com/watson/developercloud/natural-language-understanding/api/v1/) | 고급 텍스트 분석을 위한 자연어 처리                                                   | `OAuth`  |  Yes  | Unknown |
-|                                        [Yomi](https://github.com/ookii-tsuki/yomi)                                        | 일본어 토크나이저 및 형태소 분석 웹 API                                               |    No    |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Code Detection API](https://codedetectionapi.runtime.dev) | 앱 또는 데이터 파이프라인에서 코드를 감지하고, 레이블을 지정하고, 형식을 지정하고 강화합니다. | `OAuth` | Yes | Unknown |
+| [apilayer languagelayer](https://languagelayer.com/) | 173개 언어를 지원하는 언어 감지 JSON API | `OAuth` | Yes | Unknown |
+| [Aylien Text Analysis](https://docs.aylien.com/textapi/#getting-started) | 정보 검색 및 자연어 API 모음 | `apiKey` | Yes | Unknown |
+| [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | 자연어 처리 및 텍스트 분석 | `apiKey` | Yes | Yes |
+| [Detect Language](https://detectlanguage.com/) | 텍스트 언어 감지 | `apiKey` | Yes | Unknown |
+| [ELI](https://nlp.insightera.co.th/docs/v1.0) | 태국어용 자연어 처리 도구 | `apiKey` | Yes | Unknown |
+| [Google Cloud Natural](https://cloud.google.com/natural-language/docs/) | 감정, 엔티티 및 구문 분석을 포함한 자연어 이해 기술 | `apiKey` | Yes | Unknown |
+| [GeoScore](https://geoscoreapi.com) | AI 검색 인용 준비에 대한 콘텐츠 점수를 매깁니다. 0~100의 GEO 점수, 8개의 구조적 지표 및 개선 수정 사항을 반환합니다. | `apiKey` | Yes | Yes |
+| [Hirak OCR](https://ocr.hirak.site/) | 이미지를 텍스트로 - 텍스트 인식 - 이미지에서 100개 이상의 언어, 정확하고 무제한 요청 | `apiKey` | Yes | Unknown |
+| [Hirak Translation](https://translate.hirak.site/) | 가장 많이 사용되는 21개 언어 간 번역, 정확하고 무제한 요청 | `apiKey` | Yes | Unknown |
+| [Lecto Translation](https://rapidapi.com/lecto-lecto-default/api/lecto-translation/) | 무료 등급과 합리적인 가격을 제공하는 번역 API | `apiKey` | Yes | Yes |
+| [LibreTranslate](https://libretranslate.com/docs) | 17개 언어를 지원하는 번역 도구 | No | Yes | Unknown |
+| [Semantria](https://semantria.readme.io/docs) | 감정 분석, 분류 및 명명된 엔티티 추출을 포함한 텍스트 분석 | `OAuth` | Yes | Unknown |
+| [Sentiment Analysis](https://www.meaningcloud.com/developer/sentiment-analysis) | 다양한 소스의 텍스트에 대한 다국어 감정 분석 | `apiKey` | Yes | Yes |
+| [Tisane](https://tisane.ai/) | 악의적인 콘텐츠 및 법 집행 애플리케이션 탐지에 중점을 둔 텍스트 분석 | `OAuth` | Yes | Yes |
+| [Watson Natural Language Understanding](https://cloud.ibm.com/apidocs/natural-language-understanding/natural-language-understanding) | 고급 텍스트 분석을 위한 자연어 처리 | `OAuth` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 추적
 
-|                       API                        | 설명                                                        |   인증   | HTTPS |  CORS   |
-| :----------------------------------------------: | ----------------------------------------------------------- | :------: | :---: | :-----: |
-|     [Let's Count](https://letscountapi.com)      | 카운터 생성, 검색, 업데이트, 증가 및 감소                   |    No    |  Yes  | Unknown |
-|         [Postmon](http://postmon.com.br)         | 브라질 우편번호와 주문을 쉽고 빠르게 무료로 쿼리하는 API    |    No    |  No   | Unknown |
-|  [Sweden](https://developer.postnord.com/docs2)  | 운송 중인 소포에 대한 정보 제공                             | `apiKey` |  No   | Unknown |
-|    [UPS](https://www.ups.com/upsdeveloperkit)    | 배송 및 주소 정보                                           | `apiKey` |  Yes  | Unknown |
-| [WhatPulse](https://whatpulse.org/pages/webapi/) | 키보드/마우스 사용량을 측정하는 작은 애플리케이션            |    No    |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Aftership](https://developers.aftership.com/reference/quick-start) | 배송을 효율적으로 업데이트, 관리 및 추적하는 API | `apiKey` | Yes | Yes |
+| [Correios](https://cws.correios.com.br/ajuda) | Correio의 서비스를 이용하여 정보 제공 및 배송 준비를 위한 통합 | `apiKey` | Yes | Unknown |
+| [Pixela](https://pixe.la) | 습관이나 노력, 루틴을 기록하고 추적하기 위한 API | `X-Mashape-Key` | Yes | Yes |
+| [PostalPinCode](http://www.postalpincode.in/Api-Details) | 인도에서 핀코드 세부정보를 가져오기 위한 API | No | Yes | Unknown |
+| [Postmon](http://postmon.com.br) | 브라질 우편번호와 주문을 쉽고 빠르게 무료로 쿼리하는 API | No | No | Unknown |
+| [PostNord](https://developer.postnord.com/api) | 스웨덴과 덴마크의 운송 소포에 대한 정보를 제공합니다. | `apiKey` | No | Unknown |
+| [UPS](https://www.ups.com/upsdeveloperkit) | 배송 및 주소 정보 | `apiKey` | Yes | Unknown |
+| [WeCanTrack](https://docs.wecantrack.com) | 제휴사 전환을 클릭 데이터에 귀속시키기 위해 제휴사 링크에 하위 ID를 자동으로 배치합니다. | `apiKey` | Yes | Yes |
+| [WhatPulse](https://developer.whatpulse.org/#web-api) | 키보드/마우스 사용량을 측정하는 작은 애플리케이션 | No | Yes | Unknown |
+| [WhereParcel](https://whereparcel.com/docs) | 전 세계 60개 이상의 운송업체(USPS, FedEx, UPS, DHL 등)에 대한 통합 소포 추적 API | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 교통
 
-|                                                                API                                                                 | 설명                                                                        |   인증   | HTTPS |  CORS   |
-| :--------------------------------------------------------------------------------------------------------------------------------: | --------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                                        [ADS-B Exchange](https://www.adsbexchange.com/data/)                                        | 모든 항공기의 실시간 및 과거 데이터에 액세스                                |    No    |  Yes  | Unknown |
-|                                     [AIS Web](http://www.aisweb.aer.mil.br/api/doc/index.cfm)                                      | 공역 통제부(DECEA)에서 제작한 디지털 미디어의 항공 정보                     | `apiKey` |  No   | Unknown |
-|                                 [Amadeus Travel Innovation Sandbox](https://sandbox.amadeus.com/)                                  | 여행 검색 - 제한된 사용                                                     | `apiKey` |  Yes  | Unknown |
-|                                         [Aero Key, India](https://aerokey-api.vercel.app/)                                         | 인도 국내 공항 데이터                                                       |    No    |  Yes  |   No    |
-|                                            [Uber](https://developer.uber.com/products)                                             | Uber 탑승 요청 및 가격 추정                                                 | `OAuth`  |  Yes  |   Yes   |
-|                                           [Bay Area Rapid Transit](http://api.bart.gov)                                            | BART 역 및 예상 도착 시간                                                   | `apiKey` |  No   | Unknown |
-|                                          [Unofficial BART API](https://bart.trentwil.es)                                           | BART 레거시 API의 안정적 버전                                               |    No    |  Yes  | Unknown |
-|                                               [BlaBlaCar](https://dev.blablacar.com)                                               | 카셰어링 여행 검색                                                          | `apiKey` |  Yes  | Unknown |
-|           [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints)            | Transitland API                                                             |    No    |  Yes  | Unknown |
-|                                         [GraphHopper](https://graphhopper.com/api/1/docs/)                                         | 턴바이턴 안내가 포함된 A-to-B 경로 찾기                                     | `apiKey` |  Yes  | Unknown |
-|                                               [Icelandic APIs](http://docs.apis.is/)                                               | 아이슬란드에서 또는 아이슬란드에 관한 서비스를 제공하는 공개 API             |    No    |  Yes  | Unknown |
-|                                                 [Izi](http://api-docs.izi.travel/)                                                 | 여행자를 위한 오디오 가이드                                                 | `apiKey` |  Yes  | Unknown |
-|                                   [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php)                                   | 지하철 노선 지연                                                            |    No    |  No   |   No    |
-|                                                 [Navitia](https://api.navitia.io/)                                                 | 교통 데이터로 멋진 것들을 만들기 위한 공개 API                              | `apiKey` |  Yes  | Unknown |
-|                                   [Open Charge Map](https://openchargemap.org/site/develop/api)                                    | 전기 자동차 충전 위치의 전 세계 공공 등록소                                 |    No    |  Yes  | Unknown |
-|                             [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms)                              | 트랜스젠더, 인터섹스 및 성별 비순응 개인을 위한 안전한 화장실 액세스 제공   |    No    |  Yes  | Unknown |
-|                                         [Schiphol Airport](https://developer.schiphol.nl/)                                         | 스키폴 공항                                                                 | `apiKey` |  Yes  | Unknown |
-|                           [TransitLand](https://transit.land/documentation/datastore/api-endpoints.html)                           | 대중교통 집계                                                               |    No    |  Yes  | Unknown |
-|                         [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx)                          | 마르타                                                                      |    No    |  No   | Unknown |
-|                                   [Transport for Auckland, New Zealand](https://api.at.govt.nz/)                                   | 오클랜드 교통                                                               |    No    |  Yes  | Unknown |
-|                                        [Transport for Belgium](https://hello.irail.be/api/)                                        | 벨기에 교통 API                                                             |    No    |  Yes  | Unknown |
-|                         [Transport for Bordeaux, France](https://opendata.bordeaux-metropole.fr/explore/)                          | 보르도 메트로폴 대중교통 등 (프랑스)                                        | `apiKey` |  Yes  | Unknown |
-|                                   [Transport for Boston, US](https://mbta.com/developers/v3-api)                                   | MBTA API                                                                    |    No    |  No   | Unknown |
-|                                 [Transport for Budapest, Hungary](https://bkkfutar.docs.apiary.io)                                 | 부다페스트 대중교통 API                                                     |    No    |  Yes  | Unknown |
-|                               [Transport for Chicago, US](http://www.transitchicago.com/developers/)                               | CTA                                                                         |    No    |  No   | Unknown |
-|                          [Transport for Czech Republic](https://www.chaps.cz/eng/products/idos-internet)                           | 체코 교통 API                                                               |    No    |  Yes  | Unknown |
-|                          [Transport for Denver, US](http://www.rtd-denver.com/gtfs-developer-guide.shtml)                          | RTD                                                                         |    No    |  No   | Unknown |
-|                                   [Transport for Finland](https://digitransit.fi/en/developers/)                                   | 핀란드 교통 API                                                             |    No    |  Yes  | Unknown |
-|                             [Transport for Germany](http://data.deutschebahn.com/dataset/api-fahrplan)                             | 독일철도(DB) API                                                            | `apiKey` |  No   | Unknown |
-|                               [Transport for Grenoble, France](https://data.mobilites-m.fr/donnees)                                | 그르노블 대중교통                                                           |    No    |  No   |   No    |
-|                                  [Transport for Honolulu, US](http://hea.thebus.org/api_info.asp)                                  | 호놀룰루 교통 정보                                                          | `apiKey` |  No   | Unknown |
-|                                    [Transport for India](https://data.gov.in/sector/transport)                                     | 인도 대중교통 API                                                           | `apiKey` |  Yes  | Unknown |
-|                             [Transport for Lisbon, Portugal](https://emel.city-platform.com/opendata/)                             | 버스 노선, 주차 및 교통에 대한 데이터                                       | `apiKey` |  Yes  | Unknown |
-|                                      [Transport for London, England](https://api.tfl.gov.uk)                                       | TfL API                                                                     |    No    |  Yes  | Unknown |
-|                                  [Transport for Manchester, England](https://developer.tfgm.com/)                                  | TfGM 교통 네트워크 데이터                                                   | `apiKey` |  Yes  |   No    |
-|                           [Transport for Ottawa, Canada](http://www.octranspo.com/index.php/developers)                            | OC Transpo 다음 버스 도착 API                                               |    No    |  No   | Unknown |
-|                            [Transport for Paris, France](http://restratpws.azurewebsites.net/swagger/)                             | 간단한 실시간 일정                                                          |    No    |  No   | Unknown |
-|                       [Transport for Paris, France](http://data.ratp.fr/api/v1/console/datasets/1.0/search/)                       | RATP 공개 데이터 API                                                        |    No    |  No   | Unknown |
-|                                 [Transport for Philadelphia, US](http://www3.septa.org/hackathon/)                                 | SEPTA API                                                                   |    No    |  No   | Unknown |
-| [Transport for Sao Paulo, Brazil](http://www.sptrans.com.br/desenvolvedores/api-do-olho-vivo-guia-de-referencia/documentacao-api/) | SPTrans                                                                     | `OAuth`  |  No   | Unknown |
-|                                        [Transport for Sweden](https://www.trafiklab.se/api)                                        | 대중교통 소비자                                                             | `OAuth`  |  Yes  | Unknown |
-|                                  [Transport for Switzerland](https://opentransportdata.swiss/en/)                                  | 공식 스위스 대중교통 공개 데이터                                            | `apiKey` |  Yes  | Unknown |
-|                                    [Transport for Switzerland](https://transport.opendata.ch/)                                     | 스위스 대중교통 API                                                         |    No    |  Yes  | Unknown |
-|                              [Transport for The Netherlands](http://www.ns.nl/reisinformatie/ns-api)                               | NS, 기차만                                                                  | `apiKey` |  No   | Unknown |
-|                          [Transport for The Netherlands](https://github.com/skywave/KV78Turbo-OVAPI/wiki)                          | OVAPI, 전국 대중교통                                                        |    No    |  Yes  | Unknown |
-|                                    [Transport for Toronto, Canada](https://myttc.ca/developers)                                    | TTC                                                                         |    No    |  Yes  | Unknown |
-|                        [Transport for United States](http://www.nextbus.com/xmlFeedDocs/NextBusXMLFeed.pdf)                        | NextBus API                                                                 |    No    |  No   | Unknown |
-|                                 [Transport for Vancouver, Canada](https://developer.translink.ca/)                                 | TransLink                                                                   | `OAuth`  |  Yes  | Unknown |
-|                                    [Transport for Washington, US](https://developer.wmata.com/)                                    | 워싱턴 메트로 교통 API                                                      | `OAuth`  |  Yes  | Unknown |
-|                                  [WhereIsMyTransport](https://developer.whereismytransport.com/)                                   | 신흥 도시의 대중교통 데이터 플랫폼                                          | `OAuth`  |  Yes  | Unknown |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [ADS-B Exchange](https://www.adsbexchange.com/data/) | 모든 항공기의 실시간 및 과거 데이터에 액세스 | No | Yes | Unknown |
+| [airportsapi](https://airport-web.appspot.com/api/docs/) | ICAO 코드로 공항의 이름과 웹사이트 URL을 확인하세요. | No | Yes | Unknown |
+| [AIS Hub](http://www.aishub.net/api) | AIS 추적 시스템을 갖춘 모든 해양 및 내륙 선박의 실시간 데이터 | `apiKey` | No | Unknown |
+| [Amadeus for Developers](https://developers.amadeus.com/self-service) | 여행 검색 - 제한된 사용 | `OAuth` | Yes | Unknown |
+| [apilayer aviationstack](https://aviationstack.com/) | 실시간 비행 상태 및 글로벌 항공 데이터 API | `OAuth` | Yes | Unknown |
+| [Apimetro](https://apimetro.dev/swagger/index.html) | 멕시코시티 대중교통 시스템(Metro, Metrobús, Cablebús, RTP 등)에 대한 지리공간 데이터 | No | Yes | Yes |
+| [AviationAPI](https://docs.aviationapi.com) | FAA 항공 차트 및 간행물, 공항 정보 및 공항 날씨 | No | Yes | No |
+| [AZ511](https://www.az511.com/developers/doc) | ADOT API에서 트래픽 데이터에 액세스 | `apiKey` | Yes | Unknown |
+| [Bay Area Rapid Transit](http://api.bart.gov) | BART 역 및 예상 도착 시간 | `apiKey` | No | Unknown |
+| [BC Ferries](https://www.bcferriesapi.ca) | BC 페리의 항해 시간 및 수용 능력 | No | Yes | Yes |
+| [BIC-Boxtech](https://docs.bic-boxtech.org/) | 글로벌 컨테이너 함대에 대한 컨테이너 기술 세부 사항 | `OAuth` | Yes | Unknown |
+| [BlaBlaCar](https://dev.blablacar.com) | 카셰어링 여행 검색 | `apiKey` | Yes | Unknown |
+| [Boston MBTA Transit](https://www.mbta.com/developers/v3-api) | MBTA의 역 및 예상 도착 시간 | `apiKey` | Yes | Unknown |
+| [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) | 트랜짓랜드 API | No | Yes | Unknown |
+| [Compare Flight Prices](https://rapidapi.com/obryan-software-obryan-software-default/api/compare-flight-prices/) | 플랫폼 간 항공편 가격을 비교하는 API | `apiKey` | Yes | Unknown |
+| [CTS](https://api.cts-strasbourg.eu/) | CTS 실시간 API | `apiKey` | Yes | Yes |
+| [Grab](https://developer.grab.com/docs/) | 배송, 탑승 요금, 결제, 로열티 포인트를 추적하세요. | `OAuth` | Yes | Unknown |
+| [GraphHopper](https://docs.graphhopper.com/) | 단계별 안내를 통한 A-to-B 라우팅 | `apiKey` | Yes | Unknown |
+| [Icelandic APIs](http://docs.apis.is/) | 아이슬란드에서 또는 아이슬란드에 관한 서비스를 제공하는 공개 API | No | Yes | Unknown |
+| [Impala Hotel Bookings](https://docs.impala.travel/docs/booking-api/) | 호텔 콘텐츠, 요금, 객실 예약 | `apiKey` | Yes | No |
+| [Izi](http://api-docs.izi.travel/) | 여행자를 위한 오디오 가이드 | `apiKey` | Yes | Unknown |
+| [Land Transport Authority DataMall, Singapore](https://datamall.lta.gov.sg/content/dam/datamall/datasets/LTA_DataMall_API_User_Guide.pdf) | 싱가포르 교통 정보 | `apiKey` | No | Unknown |
+| [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | 지하철 노선 지연 | No | No | No |
+| [Navitia](https://doc.navitia.io/) | 교통 데이터로 멋진 것을 만들기 위한 개방형 API | `apiKey` | Yes | Unknown |
+| [Open Charge Map](https://openchargemap.org/site/develop/api) | 전기 자동차 충전 위치의 전 세계 공공 등록소 | `apiKey` | Yes | Yes |
+| [OpenSky Network](https://opensky-network.org/apidoc/index.html) | 무료 실시간 ADS-B 항공 데이터 | No | Yes | Unknown |
+| [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF 공개 API | `apiKey` | Yes | Unknown |
+| [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | 트랜스젠더, 인터섹스 및 성별 비순응 개인을 위한 안전한 화장실 액세스 제공 | No | Yes | Unknown |
+| [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | 여행 검색 - 제한된 사용 | `apiKey` | Yes | Unknown |
+| [Schiphol Airport](https://developer.schiphol.nl/) | 스키폴 공항 | `apiKey` | Yes | Unknown |
+| [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | 독일 실시간 휘발유/디젤 가격 | `apiKey` | Yes | Yes |
+| [TransitLand](https://www.transit.land/documentation/datastore/api-endpoints.html) | 대중교통 통합 | No | Yes | Unknown |
+| [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx) | 마르타 | No | No | Unknown |
+| [Transport for Auckland, New Zealand](https://dev-portal.at.govt.nz/) | 오클랜드 교통 | No | Yes | Unknown |
+| [Transport for Belgium](https://docs.irail.be/) | iRail API는 벨기에 기차 대중교통을 위한 타사 API. | No | Yes | Yes |
+| [Transport for Berlin, Germany](https://github.com/derhuerst/vbb-rest/blob/3/docs/index.md) | 타사 VBB API | No | Yes | Unknown |
+| [Transport for Bordeaux, France](https://opendata.bordeaux-metropole.fr/explore/) | 보르도 메트로폴 대중교통 등 (프랑스) | `apiKey` | Yes | Unknown |
+| [Transport for Budapest, Hungary](https://bkkfutar.docs.apiary.io) | 부다페스트 대중교통 API | No | Yes | Unknown |
+| [Transport for Chicago, US](http://www.transitchicago.com/developers/) | 시카고 교통국(CTA) | `apiKey` | No | Unknown |
+| [Transport for Czech Republic](https://www.chaps.cz/eng/products/idos-internet) | 체코 교통 API | No | Yes | Unknown |
+| [Transport for Denver, US](http://www.rtd-denver.com/gtfs-developer-guide.shtml) | 덴버 RTD 대중교통 데이터 | No | No | Unknown |
+| [Transport for Finland](https://digitransit.fi/en/developers/) | 핀란드 교통 API | No | Yes | Unknown |
+| [Transport for Germany](http://data.deutschebahn.com/dataset/api-fahrplan) | 독일철도(DB) API | `apiKey` | No | Unknown |
+| [Transport for Grenoble, France](https://www.mobilites-m.fr/pages/opendata/OpenDataApi.html) | 그르노블 대중교통 | No | No | No |
+| [Transport for Hessen, Germany](https://opendata.rmv.de/site/start.html) | RMV API(헤센 대중교통) | No | Yes | Unknown |
+| [Transport for Honolulu, US](http://hea.thebus.org/api_info.asp) | 호놀룰루 교통 정보 | `apiKey` | No | Unknown |
+| [Transport for Lisbon, Portugal](https://emel.city-platform.com/opendata/) | 버스 노선, 주차 및 교통에 대한 데이터 | `apiKey` | Yes | Unknown |
+| [Transport for London, England](https://api.tfl.gov.uk) | 런던 교통국 TfL API | `apiKey` | Yes | Unknown |
+| [Transport for Los Angeles, US](https://developer.metro.net/api/) | 실시간으로 지하철 차량 위치 및 경로 이동에 대한 데이터 | No | Yes | Unknown |
+| [Transport for Manchester, England](https://developer.tfgm.com/) | TfGM 교통 네트워크 데이터 | `apiKey` | Yes | No |
+| [Transport for Norway](https://developer.entur.org/) | 노르웨이용 전송 API 및 데이터 세트 | No | Yes | Unknown |
+| [Transport for Ottawa, Canada](https://www.octranspo.com/en/plan-your-trip/travel-tools/developers) | OC 트랜스포 API | `apiKey` | Yes | Unknown |
+| [Transport for Paris, France](http://data.ratp.fr/api/v1/console/datasets/1.0/search/) | RATP 공개 데이터 API | No | No | Unknown |
+| [Transport for Philadelphia, US](http://www3.septa.org/hackathon/) | 필라델피아 SEPTA 대중교통 API | No | No | Unknown |
+| [Transport for Sao Paulo, Brazil](http://www.sptrans.com.br/desenvolvedores/api-do-olho-vivo-guia-de-referencia/documentacao-api/) | SP트랜스 | `OAuth` | No | Unknown |
+| [Transport for Spain](https://data.renfe.com/api/1/util/snippet/api_info.html?resource_id=a2368cff-1562-4dde-8466-9635ea3a572a) | 스페인의 공공 열차 | No | Yes | Unknown |
+| [Transport for Sweden](https://www.trafiklab.se/api) | 대중교통 소비자 | `OAuth` | Yes | Unknown |
+| [Transport for Switzerland](https://opentransportdata.swiss/en/) | 공식 스위스 대중교통 공개 데이터 | `apiKey` | Yes | Unknown |
+| [Transport for Switzerland](https://transport.opendata.ch/) | 스위스 대중교통 API | No | Yes | Unknown |
+| [Transport for The Netherlands](http://www.ns.nl/reisinformatie/ns-api) | NS, 기차만 | `apiKey` | No | Unknown |
+| [Transport for The Netherlands](https://github.com/skywave/KV78Turbo-OVAPI/wiki) | OVAPI, 전국 대중교통 | No | Yes | Unknown |
+| [Transport for Toronto, Canada](https://myttc.ca/developers) | 토론토 TTC 대중교통 데이터 | No | Yes | Unknown |
+| [Transport for UK](https://developer.transportapi.com) | 영국의 교통 API 및 데이터 세트 | `apiKey` | Yes | Unknown |
+| [Transport for United States](https://retro.umoiq.com/xmlFeedDocs/NextBusXMLFeed.pdf) | 넥스트버스 API | No | No | Unknown |
+| [Transport for Vancouver, Canada](https://developer.translink.ca/) | 트랜스링크 | `OAuth` | Yes | Unknown |
+| [Transport for Washington, US](https://developer.wmata.com/) | 워싱턴 메트로 교통 API | `OAuth` | Yes | Unknown |
+| [transport.rest](https://transport.rest) | 커뮤니티가 유지 관리하고 개발자 친화적인 대중 교통 API | No | Yes | Yes |
+| [Tripadvisor](https://developer-tripadvisor.com/home/) | 호텔, 레스토랑, 명소 또는 목적지에 대한 콘텐츠 평가 | `apiKey` | Yes | Unknown |
+| [Uber](https://developer.uber.com/products) | Uber 탑승 요청 및 가격 추정 | `OAuth` | Yes | Yes |
+| [Velib metropolis, Paris, France](https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole) | 벨리브 오픈 데이터 API | No | Yes | No |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### URL 단축기
 
-|                          API                          | 설명                                       |   인증   | HTTPS |  CORS   |
-| :---------------------------------------------------: | ------------------------------------------ | :------: | :---: | :-----: |
-|    [Bitly](http://dev.bitly.com/get_started.html)     | URL 단축기 및 링크 관리                    | `OAuth`  |  Yes  | Unknown |
-|         [CleanURI](https://cleanuri.com/docs)         | URL 단축기 서비스                          |    No    |  Yes  |   Yes   |
-| [Rebrandly](https://developers.rebrandly.com/v1/docs) | 브랜드 링크 공유를 위한 맞춤형 URL 단축기  | `apiKey` |  Yes  | Unknown |
-|              [T.LY](https://t.ly/docs/)               | 짧은 링크가 있는 URL 단축기                | `apiKey` |  Yes  | Unknown |
-|           [Urlix](https://app.urlix.me/api)           | 강력한 API가 있는 무료 URL 단축기          | `apiKey` |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [1pt](https://github.com/1pt-co/api/blob/main/README.md) | 간단한 URL 단축기 | No | Yes | Yes |
+| [Bitly](http://dev.bitly.com/get_started.html) | URL 단축기 및 링크 관리 | `OAuth` | Yes | Unknown |
+| [CleanURI](https://cleanuri.com/docs) | URL 단축기 서비스 | No | Yes | Yes |
+| [ClickMeter](https://support.clickmeter.com/hc/en-us/categories/201474986) | 마케팅 링크 모니터링, 비교 및 ​​최적화 | `apiKey` | Yes | Unknown |
+| [Clico](https://cli.com/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config) | URL 단축 서비스 | `apiKey` | Yes | Unknown |
+| [Cutt.ly](https://cutt.ly/api-documentation/cuttly-links-api) | URL 단축 서비스 | `apiKey` | Yes | Unknown |
+| [Drivet URL Shortener](https://wiki.drivet.xyz/en/url-shortener/add-links) | 긴 URL을 쉽고 빠르게 단축하세요 | No | Yes | Unknown |
+| [Free Url Shortener](https://ulvis.net/developer.html) | 무료 URL Shortener는 다른 사이트와 상호 작용할 수 있는 강력한 API를 제공합니다. | No | Yes | Unknown |
+| [Git.io](https://github.blog/2011-11-10-git-io-github-url-shortener/) | Git.io URL 단축기 | No | Yes | Unknown |
+| [GoTiny](https://github.com/robvanbakel/gotiny-api) | 개발자와 최종 사용자의 사용 편의성에 초점을 맞춘 경량 URL 단축기 | No | Yes | Yes |
+| [Kutt](https://docs.kutt.it/) | 무료 최신 URL 단축기 | `apiKey` | Yes | Yes |
+| [Mgnet.me](http://mgnet.me/api.html) | 토렌트 URL 단축 API | No | Yes | No |
+| [owo](https://owo.vc/api) | 간단한 링크 난독화기/단축기 | No | Yes | Unknown |
+| [Rebrandly](https://developers.rebrandly.com/v1/docs) | 브랜드 링크 공유를 위한 맞춤형 URL 단축기 | `apiKey` | Yes | Unknown |
+| [Short Link](https://github.com/FayasNoushad/Short-Link-API) | 짧은 URL은 너무 많은 도메인을 지원합니다. | No | Yes | Unknown |
+| [Shrtcode](https://shrtco.de/docs) | 여러 도메인이 있는 URL 단축기 | No | Yes | Yes |
+| [Shrtlnk](https://shrtlnk.dev/developer) | 간단하고 효율적인 짧은 링크 생성 | `apiKey` | Yes | Yes |
+| [TinyURL](https://tinyurl.com/app/dev) | 긴 URL을 줄이세요 | `apiKey` | Yes | No |
+| [UrlBae](https://urlbae.com/developers) | 간단하고 효율적인 짧은 링크 생성 | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 차량
 
-|                                  API                                   | 설명                                                                       |   인증   | HTTPS |  CORS   |
-| :--------------------------------------------------------------------: | -------------------------------------------------------------------------- | :------: | :---: | :-----: |
-| [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | 경제연구소 재단 - Fipe의 차량 정보                                         |    No    |  Yes  | Unknown |
-|      [CarsXE API](https://api.carsxe.com/?ref=public-apis-github)      | 차량 데이터 및 VIN 디코더, 사양, 번호판, 시장 가치, 소유 비용 및 이미지   | `apiKey` |  Yes  | Unknown |
-|     [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default)     | 차량 정보, 가격, 구성 등                                                  | `apiKey` |  Yes  |   No    |
-|       [Mercedes-Benz](https://developer.mercedes-benz.com/apis)        | 텔레매틱스 데이터, 원격 차량 기능 액세스, 차량 구성 도구, 서비스 딜러 위치 | `apiKey` |  Yes  |   No    |
-|                [NHTSA](https://vpic.nhtsa.dot.gov/api/)                | NHTSA 제품 정보 카탈로그 및 차량 목록                                      |    No    |  Yes  | Unknown |
-|                 [Smartcar](https://smartcar.com/docs/)                 | 차량 잠금/해제 및 주행거리계 읽기, 위치 등 데이터 가져오기. 대부분의 신차에서 작동 | `OAuth`  |  Yes  |   Yes   |
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | 경제연구소 재단 - Fipe의 차량 정보 | No | Yes | No |
+| [Helipaddy sites](https://helipaddy.com/api/) | 헬리콥터 및 승객용 드론 착륙 지점 디렉토리, Helipaddy 데이터 등 | `apiKey` | Yes | Unknown |
+| [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default) | 차량 정보, 가격, 구성 등 | `apiKey` | Yes | No |
+| [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | 텔레매틱스 데이터, 원격 차량 기능 액세스, 차량 구성 도구, 서비스 딜러 위치 | `apiKey` | Yes | No |
+| [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA 제품 정보 카탈로그 및 차량 목록 | No | Yes | Unknown |
+| [Smartcar](https://smartcar.com/docs/) | 차량 잠금/해제 및 주행거리계 읽기, 위치 등 데이터 가져오기. 대부분의 신차에서 작동 | `OAuth` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 비디오
 
-|                                                API                                                 | 설명                                                                                                      |   인증   | HTTPS |  CORS   |
-| :------------------------------------------------------------------------------------------------: | -------------------------------------------------------------------------------------------------------- | :------: | :---: | :-----: |
-|                      [An API of Ice And Fire](https://anapioficeandfire.com/)                      | 왕좌의 게임 API                                                                                              |    No    |  Yes  | Unknown |
-|                          [Bob's Burgers API](https://bobsburgersapi.com/)                          | 밥스 버거 API - 쇼의 수백 개 캐릭터, 에피소드, 러닝개그, 이미지 데이터 포함 |    No    |  Yes  |   Yes   |
-|               [Breaking Bad Quotes](https://github.com/shevabam/breaking-bad-quotes)               | 브레이킹 배드 명대사 모음                                                                                         |    No    |  Yes  | Unknown |
-|                  [Czech Television](http://www.ceskatelevize.cz/xml/tv-program/)                   | 체코 TV 방송 프로그램                                                                                         |    No    |  No   | Unknown |
-|                         [Dailymotion](https://developer.dailymotion.com/)                          | 데일리모션 개발자 API                                                                                        | `OAuth`  |  Yes  | Unknown |
-|                            [Dune](https://github.com/ywalia01/dune-api)                            | 듄 API                                                                                                         |    No    |  Yes  | Unknown |
-|                             [Harry Potter](https://www.potterapi.com/)                             | 해리포터 API                                                                                                 | `apiKey` |  Yes  |   Yes   |
-|                           [Open Movie Database](http://www.omdbapi.com/)                           | 영화 정보                                                                                                | `apiKey` |  Yes  | Unknown |
-|                    [Owen Wilson Wow](https://owen-wilson-wow-api.onrender.com/)                    | 배우 오웬 윌슨의 영화 속 "와우" 감탄사 API                                                         |    No    |  Yes  |   Yes   |
-|                                 [Potter DB](https://potterdb.com)                                  | 해리포터 유니버스 데이터: 캐릭터, 영화, 도서, 마법, 물약                               |    No    |  Yes  | Unknown |
-| [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | 텔레비전 (론 스완슨 명언)                                                                                                       |    No    |  Yes  | Unknown |
-|                                 [Rendi](https://rendi.dev/)                                        | FFmpeg API                                                                                                       | `apiKey` |  Yes  | Unknown |
-|                             [Shrek Quotes](https://shrekofficial.com)                              | 슈렉 명대사 모음 (주로 명대사)                                                                         |    No    |  Yes  |   Yes   |
-|               [South Park Quotes](https://github.com/Thatskat/southpark-quotes-api)                | 사우스파크의 최고 명대사들을 가져올 수 있는 간단한 API!                          |    No    |  Yes  |   Yes   |
-|                                     [STAPI](https://stapi.co)                                      | 스타트렉 관련 모든 정보                                                                              |    No    |  Yes  |   Yes   |
-|                        [TMDb](https://www.themoviedb.org/documentation/api)                        | 커뮤니티 기반 영화 데이터                                                                                       | `apiKey` |  Yes  | Unknown |
-|                                [Trakt](https://trakt.tv/b/api-docs)                                | 영화 및 TV 데이터                                                                                                | `apiKey` |  Yes  |   Yes   |
-|                                [TVMaze](http://www.tvmaze.com/api)                                 | TV 쇼 데이터                                                                                                     |    No    |  No   | Unknown |
-|                               [Vimeo](https://developer.vimeo.com/)                                | 비메오 개발자 API                                                                                              | `OAuth`  |  Yes  | Unknown |
-|                         [YouTube](https://developers.google.com/youtube/)                          | 사이트와 앱에 YouTube 기능 추가                                                                 | `OAuth`  |  Yes  | Unknown |
-|                                 [Shotstack](https://shotstack.io/)                                 | 클라우드 기반 비디오 편집 API로 비디오 애플리케이션 개발                                                    | `apiKey` |  Yes  | Unknown |
-
----
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [An API of Ice And Fire](https://anapioficeandfire.com/) | 왕좌의 게임 API | No | Yes | Unknown |
+| [Bob's Burgers](https://bobs-burgers-api-ui.herokuapp.com) | 밥스 버거 API | No | Yes | Yes |
+| [Breaking Bad](https://breakingbadapi.com/documentation) | 브레이킹 배드 API | No | Yes | Unknown |
+| [Breaking Bad Quotes](https://github.com/shevabam/breaking-bad-quotes) | 브레이킹 배드 명대사 모음 | No | Yes | Unknown |
+| [Catalogopolis](https://api.catalogopolis.xyz/docs/) | 닥터후 API | No | Yes | Unknown |
+| [Catch The Show](https://catchtheshow.herokuapp.com/api/documentation) | next-episode.net용 REST API | No | Yes | Unknown |
+| [Czech Television](http://www.ceskatelevize.cz/xml/tv-program/) | 체코 TV 방송 프로그램 | No | No | Unknown |
+| [Dailymotion](https://developer.dailymotion.com/) | 데일리모션 개발자 API | `OAuth` | Yes | Unknown |
+| [Dune](https://github.com/ywalia01/dune-api) | 듄 API | No | Yes | Yes |
+| [Final Space](https://finalspaceapi.com/docs/) | 최종 공간 API | No | Yes | Yes |
+| [Game of Thrones Quotes](https://gameofthronesquotes.xyz/) | 왕좌의 게임 인용문 | No | Yes | Unknown |
+| [Harry Potter Charactes](https://hp-api.herokuapp.com/) | 이미지가 포함된 해리포터 캐릭터 데이터 | No | Yes | Unknown |
+| [IMDb-API](https://imdb-api.com/) | 영화, 연재물, 출연진 정보를 수신하기 위한 API | `apiKey` | Yes | Unknown |
+| [IMDbOT](https://github.com/SpEcHiDe/IMDbOT) | 비공식 IMDb 영화/시리즈 정보 | No | Yes | Yes |
+| [JSON2Video](https://json2video.com) | 프로그래밍 방식으로 비디오 생성 및 편집: 워터마크, 크기 조정, 슬라이드쇼, 음성 해설, 텍스트 애니메이션 | `apiKey` | Yes | No |
+| [Lucifer Quotes](https://github.com/shadowoff09/lucifer-quotes) | 루시퍼 인용문을 반환합니다. | No | Yes | Unknown |
+| [MCU Countdown](https://github.com/DiljotSG/MCU-Countdown) | 다음 MCU 영화 카운트다운 | No | Yes | Yes |
+| [Motivational Quotes](https://nodejs-quoteapp.herokuapp.com/) | 무작위 동기 부여 따옴표 | No | Yes | Unknown |
+| [Movie Quote](https://github.com/F4R4N/movie-quote/) | 무작위 영화 및 시리즈 인용문 | No | Yes | Yes |
+| [Open Movie Database](http://www.omdbapi.com/) | 영화 정보 | `apiKey` | Yes | Unknown |
+| [Owen Wilson Wow](https://owen-wilson-wow-api.herokuapp.com) | 영화에서 배우 오웬 윌슨의 "와우" 감탄사를 위한 API | No | Yes | Yes |
+| [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | 텔레비전 (론 스완슨 명언) | No | Yes | Unknown |
+| [Simkl](https://simkl.docs.apiary.io) | 영화, TV 및 애니메이션 데이터 | `apiKey` | Yes | Unknown |
+| [STAPI](http://stapi.co) | 스타트렉에 관한 모든 정보 | No | No | No |
+| [Stranger Things Quotes](https://github.com/shadowoff09/strangerthings-quotes) | 낯선 것들 인용문 반환 | No | Yes | Unknown |
+| [Stream](https://api.stream.cz/graphiql) | 무료 체코 인터넷 TV, 영화, 시리즈 및 온라인 비디오 | No | Yes | No |
+| [Stromberg Quotes](https://www.stromberg-api.de/) | Stromberg 인용문 등을 반환합니다. | No | Yes | Unknown |
+| [SWAPI](https://swapi.dev/) | 당신이 원했던 모든 스타워즈 데이터 | No | Yes | Yes |
+| [SWAPI](https://www.swapi.tech) | 스타워즈의 모든 것 | No | Yes | Yes |
+| [SWAPI GraphQL](https://graphql.org/swapi-graphql) | 스타워즈 GraphQL API | No | Yes | Unknown |
+| [The Lord of the Rings](https://the-one-api.dev/) | 반지의 제왕 API | `apiKey` | Yes | Unknown |
+| [The Vampire Diaries](https://vampire-diaries-api.netlify.app/) | TV 프로그램 데이터 | `apiKey` | Yes | Yes |
+| [ThronesApi](https://thronesapi.com/) | 이미지가 포함된 왕좌의 게임 캐릭터 데이터 | No | Yes | Unknown |
+| [TMDb](https://www.themoviedb.org/documentation/api) | 커뮤니티 기반 영화 데이터 | `apiKey` | Yes | Unknown |
+| [TrailerAddict](https://www.traileraddict.com/trailerapi) | TrailerAddict에서 예고편을 쉽게 삽입 | `apiKey` | No | Unknown |
+| [Trakt](https://trakt.docs.apiary.io/) | 영화 및 TV 데이터 | `apiKey` | Yes | Yes |
+| [TVDB](https://thetvdb.com/api-information) | 텔레비전 데이터 | `apiKey` | Yes | Unknown |
+| [TVMaze](http://www.tvmaze.com/api) | TV 쇼 데이터 | No | No | Unknown |
+| [uNoGS](https://rapidapi.com/unogs/api/unogsng) | 비공식 Netflix 온라인 글로벌 검색, 한 곳에서 모든 Netflix 지역 검색 | `apiKey` | Yes | Yes |
+| [Vimeo](https://developer.vimeo.com/) | 비메오 개발자 API | `OAuth` | Yes | Unknown |
+| [Watchmode](https://api.watchmode.com/) | 영화 및 프로그램의 스트리밍 이용 가능 여부를 확인하기 위한 API | `apiKey` | Yes | Unknown |
+| [Web Series Quotes Generator](https://github.com/yogeshwaran01/web-series-quotes) | API는 다양한 웹 시리즈 견적 이미지를 생성합니다. | No | Yes | Yes |
+| [YouTube](https://developers.google.com/youtube/) | 사이트와 앱에 YouTube 기능 추가 | `OAuth` | Yes | Unknown |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
 ### 날씨
 
-|                                          API                                           | 설명                                                                                                                    |   인증   | HTTPS |  CORS   |
-| :------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------ | :------: | :---: | :-----: |
-|                   [7Timer!](http://www.7timer.info/doc.php?lang=en)                    | 날씨 정보, 특히 천체 관측용 날씨                                                                                           |    No    |  No   | Unknown |
-|                    [APIXU](https://www.apixu.com/doc/request.aspx)                     | 날씨                                                                                                                        | `apiKey` |  Yes  | Unknown |
-|                          [DWD API](https://dwd.api.bund.dev/)                          | 독일 기상청(DWD) API: 날씨 데이터, 특정 기상관측소 데이터, 경보(지역, 연안, 바다, 알프스) |    No    |  Yes  | Unknown |
-|     [Meteoblue](https://content.meteoblue.com/en/business-solutions/weather-apis)      | 100개 이상의 기상 변수를 가진 글로벌 날씨 데이터, 14일 예보 및 4일 과거 데이터                                     | `apiKey` |  Yes  |   Yes   |
-|         [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation)         | 날씨 및 기후 데이터                                                                                                       |    No    |  Yes  | Unknown |
-|                [NOAA Climate Data](https://www.ncdc.noaa.gov/cdo-web/)                 | 날씨 및 기후 데이터                                                                                                       | `apiKey` |  Yes  | Unknown |
-|               [ODWeather](http://api.oceandrivers.com/static/docs.html)                | 날씨 및 날씨 웹캠                                                                                                    |    No    |  No   | Unknown |
-|                         [Open-Meteo](https://open-meteo.com/)                          | 비상업적 용도를 위한 글로벌 일기예보 API                                                                             |    No    |  Yes  |   Yes   |
-|                            [OpenUV](https://www.openuv.io)                             | 실시간 자외선 지수 예보                                                                                                    | `apiKey` |  Yes  | Unknown |
-|                    [OpenWeatherMap](http://openweathermap.org/api)                     | 날씨                                                                                                                        | `apiKey` |  No   | Unknown |
-|                         [Storm Glass](https://stormglass.io/)                          | 여러 소스의 글로벌 해양 날씨                                                                                    | `apiKey` |  Yes  |   Yes   |
-|              [Weather Hacks](http://weather.livedoor.com/weather_hacks/)               | 일본 날씨                                                                                                             |    No    |  No   |   No    |
-|                      [Weatherbit](https://www.weatherbit.io/api)                       | 날씨                                                                                                                        | `apiKey` |  Yes  | Unknown |
-|                      [Stormglass](https://docs.stormglass.io/#/)                       | 세계에서 가장 신뢰받는 기상 기관들의 날씨 예보 및 과거 데이터를 하나의 API로                | `apiKey` |  Yes  | Unknown |
-| [National Weather Service API](https://www.weather.gov/documentation/services-web-api) | 세계에서 가장 신뢰받는 기상 기관들의 날씨 예보 및 과거 데이터를 하나의 API로                |    No    |  Yes  | Unknown |
-
----
+| API | 설명 | 인증 | HTTPS | CORS |
+| :--- | --- | :---: | :---: | :---: |
+| [Weatherstack](https://weatherstack.com/?utm_source=Github&utm_medium=Referral&utm_campaign=Public-apis-repo-Best-sellers) | 실시간 및 과거 세계 기상 데이터 API | `apiKey` | Yes | Unknown |
+| [7Timer!](http://www.7timer.info/doc.php?lang=en) | 날씨 정보, 특히 천체 관측용 날씨 | No | No | Unknown |
+| [AccuWeather](https://developer.accuweather.com/apis) | 날씨 및 예측 데이터 | `apiKey` | No | Unknown |
+| [Aemet](https://opendata.aemet.es/centrodedescargas/inicio) | 스페인의 날씨 및 예측 데이터 | `apiKey` | Yes | Unknown |
+| [APIXU](https://www.apixu.com/doc/request.aspx) | 날씨 | `apiKey` | Yes | Unknown |
+| [AQICN](https://aqicn.org/api/) | 1000개 이상의 도시에 대한 대기질 지수 데이터 | `apiKey` | Yes | Unknown |
+| [AviationWeather](https://www.aviationweather.gov/dataserver) | NOAA 항공 일기예보 및 관측 | No | Yes | Unknown |
+| [ColorfulClouds](https://open.caiyunapp.com/ColorfulClouds_Weather_API) | 날씨 | `apiKey` | Yes | Yes |
+| [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/) | 바스크 지방의 기상 데이터 | `apiKey` | Yes | Unknown |
+| [Foreca](https://developer.foreca.com) | 날씨 | `OAuth` | Yes | Unknown |
+| [HG Weather](https://hgbrasil.com/status/weather) | 브라질 도시에 대한 일기 예보 데이터를 제공합니다. | `apiKey` | Yes | Yes |
+| [Hong Kong Obervatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | 기상정보, 지진정보, 기후정보 제공 | No | Yes | Unknown |
+| [IPMA](https://api.ipma.pt/open-data/) | 포르투갈어 날씨 및 기후 데이터 | No | Yes | Unknown |
+| [MetaWeather](https://www.metaweather.com/api/) | 날씨 | No | Yes | No |
+| [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | 날씨 및 기후 데이터 | `User-Agent` | Yes | Unknown |
+| [Micro Weather](https://m3o.com/weather/api) | 실시간 일기예보 및 과거 데이터 | `apiKey` | Yes | Unknown |
+| [ODWeather](http://api.oceandrivers.com/static/docs.html) | 날씨 및 날씨 웹캠 | No | No | Unknown |
+| [Oikolab](https://docs.oikolab.com) | NOAA 및 ECMWF에서 제공하는 70년 이상의 전 세계 시간별 기록 및 예측 기상 데이터 | `apiKey` | Yes | Yes |
+| [Open-Meteo](https://open-meteo.com/) | 비상업적 용도를 위한 글로벌 일기예보 API | No | Yes | Yes |
+| [openSenseMap](https://api.opensensemap.org/) | senseBox라는 개인 기상 관측소의 데이터 | No | Yes | Yes |
+| [OpenUV](https://www.openuv.io) | 실시간 자외선 지수 예보 | `apiKey` | Yes | Unknown |
+| [OpenWeatherMap](https://openweathermap.org/api) | 날씨 | `apiKey` | Yes | Unknown |
+| [Pirate Weather](https://pirateweather.net/en/latest/) | Dark Sky와 유사한 예측 데이터를 제공하는 무료 날씨 API | No | Yes | Yes |
+| [QWeather](https://dev.qweather.com/en/) | 위치 기반 날씨 데이터 | `apiKey` | Yes | Yes |
+| [RainViewer](https://www.rainviewer.com/api.html) | 인터넷을 통해 다양한 웹사이트에서 수집된 레이더 데이터 | No | Yes | Unknown |
+| [Storm Glass](https://stormglass.io/) | 여러 소스의 글로벌 해양 날씨 | `apiKey` | Yes | Yes |
+| [Tomorrow](https://docs.tomorrow.io) | 독점 기술로 구동되는 날씨 API | `apiKey` | Yes | Unknown |
+| [US Weather](https://www.weather.gov/documentation/services-web-api) | 세계에서 가장 신뢰받는 기상 기관들의 날씨 예보 및 과거 데이터를 하나의 API로 | No | Yes | Yes |
+| [Visual Crossing](https://www.visualcrossing.com/weather-api) | 글로벌 역사 및 일기예보 데이터 | `apiKey` | Yes | Yes |
+| [weather-api](https://github.com/robertoduessmann/weather-api) | 날씨를 확인하는 RESTful 무료 API | No | Yes | No |
+| [WeatherAPI](https://www.weatherapi.com/) | 천문학 및 Geolocation API와 같은 다른 기능을 갖춘 날씨 API | `apiKey` | Yes | Yes |
+| [Weatherbit](https://www.weatherbit.io/api) | 날씨 | `apiKey` | Yes | Unknown |
+| [wttr.in](https://wttr.in/:help) | 터미널의 날씨는 JSON 출력을 지원합니다. | No | Yes | Yes |
+| [Yandex.Weather](https://yandex.com/dev/weather/) | 특정 위치의 기상 상태를 평가합니다. | `apiKey` | Yes | No |
 
 **[⬆ 목차로 돌아가기](#목차)**
-


### PR DESCRIPTION
## Summary
- Regenerate GLOBAL_PUBLIC_APIS_KR.md from public-apis/public-apis instead of public-api-lists/public-api-lists
- Pin the upstream source commit in the document header
- Include 51 translated sections, 1,479 main API rows, and 10 APILayer rows

## Verification
- Parsed generated Markdown: 51 sections, 1,479 main API rows, 10 APILayer rows
- Verified zero malformed table rows
- Verified zero descriptions without Korean text
- Ran git diff --check for GLOBAL_PUBLIC_APIS_KR.md

## Scope
- Only GLOBAL_PUBLIC_APIS_KR.md is included in this PR
- Existing README.md, README_EN.md, and report files were intentionally left out