### PR TITLE
Add YES24 Open API

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@
 | [G마켓 Open API](https://etapi.gmarket.com/pages/API-%EA%B0%80%EC%9D%B4%EB%93%9C)                    | G마켓 상품검색 및 카테고리 API          | `apiKey` |
 | [G마켓/옥션 ESM Trading API](https://etapi.gmarket.com/category/%EA%B3%B5%EC%A7%80)                  | 이베이코리아 통합 판매자 도구           | `JWT`    |
 | [NHN커머스 개발자센터](https://devcenter.nhn-commerce.com/)                                          | 고도몰 API 연동 및 샘플 코드 제공       | `apiKey` |
+| [예스24 Open API](https://developers.yes24.com)                                                      | 예스24 상품검색 및 베스트셀러 API       | `apiKey` |
 
 **[⬆ 목차로 돌아가기](#목차)**
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -707,6 +707,7 @@
 | [Naver Shopping Search API](https://developers.naver.com/docs/serviceapi/search/shopping/shopping.md)   | Naver Shopping product search service                | `apiKey` |
 | [NHN Commerce Developer Center](https://devcenter.nhn-commerce.com/)                                    | GodomMall API integration and sample code provision  | `apiKey` |
 | [WeMakePrice Login](https://developer.login.wonders.work/)                                              | WeMakePrice login OAuth 2.0 (partner companies only) | `OAuth`  |
+| [YES24 Open API](https://developers.yes24.com)                                                          | YES24 product search and bestseller API              | `apiKey` |
 
 **[⬆ Back to Table of Contents](#table-of-contents)**
 


### PR DESCRIPTION
## Add YES24 Open API

`쇼핑 & 이커머스` / `Shopping & E-commerce` 섹션에 예스24 Open API를 추가합니다.

### 추가 내용
- **README.md** — `쇼핑 & 이커머스` 섹션
- **README_EN.md** — `Shopping & E-commerce` 섹션

| API | 설명 | 인증 |
| --- | --- | --- |
| [예스24 Open API](https://developers.yes24.com) | 예스24 상품검색 및 베스트셀러 API | `apiKey` |

### API 정보
- 예스24가 제공하는 도서·상품 데이터 Open API (상품검색, 상세, 베스트셀러, 신상품 등)
- 인증: `X-Api-Key` (개발자 센터에서 발급)
- 개발자 센터: https://developers.yes24.com

### Checklist
- [x] 해당 섹션(쇼핑 & 이커머스)에 추가
- [x] 표 형식(`| API | 설명 | 인증 |`) 준수
- [x] 인증값 가이드 허용값(`apiKey`) 사용
- [x] README.md / README_EN.md 모두 반영