### PR TITLE
죽은 Aylien 링크 제거 및 뉴스 섹션에 APITube 추가

### DIFF
--- a/GLOBAL_PUBLIC_APIS_KR.md
+++ b/GLOBAL_PUBLIC_APIS_KR.md
@@ -1272,6 +1272,7 @@
 | [The Old Reader](https://github.com/theoldreader/api) | RSS 리더 | `apiKey` | Yes | Unknown |
 | [TheNews](https://www.thenewsapi.com/) | 집계된 헤드라인, 주요 기사 및 실시간 뉴스 JSON API | `apiKey` | Yes | Yes |
 | [Trove](https://trove.nla.gov.au/about/create-something/using-api) | 1000개에 달하는 디지털 신문 컬렉션을 호주 국립도서관에서 검색하세요. | `apiKey` | Yes | Unknown |
+| [APITube](https://apitube.io/) | 감정 분석 및 개체 추출을 포함한 다국어 실시간 뉴스 검색 | `apiKey` | Yes | Yes |
 
 **[⬆ 목차로 돌아가기](#목차)**
 
@@ -1678,7 +1679,6 @@
 | :--- | --- | :---: | :---: | :---: |
 | [Code Detection API](https://codedetectionapi.runtime.dev) | 앱 또는 데이터 파이프라인에서 코드를 감지하고, 레이블을 지정하고, 형식을 지정하고 강화합니다. | `OAuth` | Yes | Unknown |
 | [apilayer languagelayer](https://languagelayer.com/) | 173개 언어를 지원하는 언어 감지 JSON API | `OAuth` | Yes | Unknown |
-| [Aylien Text Analysis](https://docs.aylien.com/textapi/#getting-started) | 정보 검색 및 자연어 API 모음 | `apiKey` | Yes | Unknown |
 | [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | 자연어 처리 및 텍스트 분석 | `apiKey` | Yes | Yes |
 | [Detect Language](https://detectlanguage.com/) | 텍스트 언어 감지 | `apiKey` | Yes | Unknown |
 | [ELI](https://nlp.insightera.co.th/docs/v1.0) | 태국어용 자연어 처리 도구 | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## 변경 사항

### 1. 죽은 링크 제거 — Aylien Text Analysis (텍스트 분석)

`docs.aylien.com` 은 DNS A 레코드가 없어 더 이상 접속되지 않습니다. Aylien 은 Quantexa 에 인수되었고 도메인이 폐기되었습니다. `aylien.com` 의 모든 하위 도메인(`docs.`, `api.`, `developer.`, `newsapi.`)도 동일합니다. 2026-08-21 확인.

#26 (Naver Shorten URL 제거)과 같은 맥락의 정리입니다.

### 2. 뉴스 섹션에 APITube 추가

| 항목 | 값 |
|---|---|
| 인증 | `apiKey` |
| HTTPS | Yes |
| CORS | Yes (`access-control-allow-origin: *` 확인) |

무료 플랜은 카드 없이 하루 100 요청입니다. 문서 요약이 아니라 실제 응답 기준으로 문서 단위 감정(`overall`/`title`/`body`)과 개체 단위 감정을 제공합니다.

CONTRIBUTING 에 따라 카테고리 맨 아래에 추가했습니다.

두 변경을 분리한 PR 이 더 편하시면 말씀해 주세요.