### PR TITLE
금융 & 결제 섹션에 한국주식데이터(인증 없는 주식 시세·공시 JSON/CSV) 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@
 | [KB API 포탈](https://apiportal.kbfg.com/)                            | KB금융그룹 종합 금융 API 서비스 (800+ API 제공)     | `OAuth`       |
 | [KB국민은행 Open API](https://obizapi.kbstar.com/quics?page=C108082)  | KB 종합 금융서비스 및 BaaS 플랫폼                 | `OAuth`       |
 | [NH농협은행 Open API](https://developers.nonghyup.com/center/CE_1020) | 농협 금융 API 개발자센터                        | `OAuth`       |
+| [한국주식데이터](https://aikstockdata.com/datasets) | 코스피·코스닥·코넥스 전 종목 T+1 확정 종가·DART 공시(접수 시각)·분기 실적 JSON/CSV, 가입 없이 조회 | `No` |
 
 **[⬆ 목차로 돌아가기](#목차)**
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -564,6 +564,7 @@
 | [Toss Pay API](https://docs-pay.toss.im/reference)                                 | Payment service API through Toss (TLS 1.2+ required)                                         | `apiKey`      |
 | [Toss Payments](https://docs.tosspayments.com/reference)                           | Integrated payment API (card, virtual account, simple payment)                               | `apiKey`      |
 | [Woori Bank Open API](https://developer.wooribank.com/apiservice)                  | Fintech developer one-stop support service                                                   | `OAuth`       |
+| [Korea Stock Data (aikstockdata)](https://aikstockdata.com/en/api) | T+1 confirmed closing prices for all KOSPI/KOSDAQ/KONEX stocks, DART filings with receipt time, quarterly earnings as JSON/CSV, no signup | `No` |
 
 **[⬆ Back to Table of Contents](#table-of-contents)**
 


### PR DESCRIPTION
## 변경 사항

`금융 & 결제` / `Finance & Payment` 섹션 맨 아래에 한 줄씩 추가합니다(CONTRIBUTING 대로).

| 항목 | 값 |
|---|---|
| 인증 | `No` — 가입·API 키 없이 GET 으로 받습니다 |
| HTTPS | Yes |
| CORS | Yes (`Access-Control-Allow-Origin: *` 2026-09-11 확인) |
| 형식 | JSON · CSV · OpenAPI 3.1 명세 https://aikstockdata.com/openapi.json |
| 원천 | 금융위원회 주식시세정보(공공데이터포털) · 금융감독원 DART |
| 갱신 | 매 거래일 1회, 전 영업일 확정 종가(T+1) — 실시간 시세가 아닙니다 |
| 이용 조건 | `aiksd-public-1.1` — 출처를 표기하면 비영리 목적으로 인용·이용할 수 있고, 상업적 재배포는 허용하지 않습니다. (2026-09-14 변경) |

확인용 호출(삼성전자 한 종목):

    curl https://aikstockdata.com/data/public/s/005930.json

이 데이터를 운영하는 본인이 올리는 PR 입니다. 목록 성격에 맞지 않으면 닫아 주셔도 됩니다.
